### PR TITLE
Async Responder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "^0.3" }
+rental = "^0.5"
 tokio = { version = "^0.2", features = ["rt-core", "time"], optional = true }
 async-std = { version = "^1", features = ["unstable"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,14 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "^0.3" }
-tokio = { version = "^0.2", features = ["rt-core"], optional = true }
+tokio = { version = "^0.2", features = ["rt-core", "time"], optional = true }
+async-std = { version = "^1", features = ["unstable"], optional = true }
 
 [features]
-default = ["tokio_spawn"]
-tokio_spawn = ["tokio"]
+with-tokio-0_2 = ["tokio"]
+with-async_std-1 = ["async-std"]
 
 [[example]]
 name = "basic_tokio"
 path = "examples/basic_tokio.rs"
-required-features = ["tokio_spawn", "tokio/full"]
+required-features = ["with-tokio-0_2", "tokio/full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "^0.3" }
-rental = "^0.5"
 tokio = { version = "^0.2", features = ["rt-core", "time"], optional = true }
 async-std = { version = "^1", features = ["unstable"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ with-async_std-1 = ["async-std"]
 name = "basic_tokio"
 path = "examples/basic_tokio.rs"
 required-features = ["with-tokio-0_2", "tokio/full"]
+
+[[example]]
+name = "basic_tokio_async"
+path = "examples/basic_tokio_async.rs"
+required-features = ["with-tokio-0_2", "tokio/full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,16 @@ path = "examples/basic_tokio_async.rs"
 required-features = ["with-tokio-0_2", "tokio/full"]
 
 [[example]]
+name = "basic_async_std"
+path = "examples/basic_async_std.rs"
+required-features = ["with-async_std-1", "async-std/attributes"]
+
+[[example]]
+name = "basic_async_std_async"
+path = "examples/basic_async_std_async.rs"
+required-features = ["with-async_std-1", "async-std/attributes"]
+
+[[example]]
 name = "crude_bench"
 path = "examples/crude_bench.rs"
 required-features = ["with-tokio-0_2", "tokio/full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ required-features = ["with-tokio-0_2", "tokio/full"]
 name = "basic_tokio_async"
 path = "examples/basic_tokio_async.rs"
 required-features = ["with-tokio-0_2", "tokio/full"]
+
+[[example]]
+name = "crude_bench"
+path = "examples/crude_bench.rs"
+required-features = ["with-tokio-0_2", "tokio/full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "xtra"
 version = "0.1.0"
+description = "A tiny actor framework"
 authors = ["Restioson <restiosondev@gmail.com>"]
 edition = "2018"
+license = "MPL-2.0"
 
 [dependencies]
 futures = { version = "^0.3" }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
 # xtra
-A tiny actor crate. It is modelled around Actix.
- 
-At the moment, it is a toy crate, but we might try use it in [Vertex](https://github.com/Restioson/vertex) for fun (and to replace [Actix](https://github.com/actix/actix)).
+A tiny (<1k LOC) actor framework. It is modelled around Actix. It's probably best to not use this production.
+
+## Features
+- Asynchronous and synchronous responders
+- Simple asynchronous message handling interface which allows `async`/`await` syntax (no more `ActorFuture` - 
+asynchronous responders just return `impl Future`)
+- Does not depend on its own runtime and can be run with any futures executor ([Tokio](https://tokio.rs/) and 
+[async-std](https://async.rs/) have the `Actor::spawn` convenience method implemented out of the box).
+- Quite fast (<200ns time from sending a message to it being processed for sending without waiting for a result)
+
+## To do
+- Thread-local actors that are `!Send`
+- Documentation
+- Actor notifications (sending messages to self) and creating an address from the actor's context
+- Scheduling of repeated-at-interval and time-delayed messages for actors
+
+## Limitations
+The main limitation of this crate is that it extensively uses unstable features. For example, to get rid of
+`ActorFuture`, [Generic Associated Types (GATs)](https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md)
+must be used. This is an incomplete and unstable feature, which [appears to be a way off from stabilisation](https://github.com/rust-lang/rust/issues/44265).
+It also uses [`impl Trait` Type Aliases](https://github.com/rust-lang/rfcs/pull/2515) to avoid `Box`ing the futures
+returned from the `AsyncHandler` trait (the library, however, is not alloc-free). This means that it requires nightly to
+use, and may be unstable.

--- a/examples/basic_async_std.rs
+++ b/examples/basic_async_std.rs
@@ -18,13 +18,15 @@ impl Message for Print {
 }
 
 impl Handler<Print> for Printer {
+    type Responder = ();
+
     fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;
         println!("Printing {}. Printed {} times so far.", print.0, self.times);
     }
 }
 
-#[tokio::main]
+#[async_std::main]
 async fn main() {
     let addr = Printer::new().spawn();
     loop {

--- a/examples/basic_async_std_async.rs
+++ b/examples/basic_async_std_async.rs
@@ -31,7 +31,7 @@ impl AsyncHandler<Print> for Printer {
     }
 }
 
-#[tokio::main]
+#[async_std::main]
 async fn main() {
     let addr = Printer::new().spawn();
     loop {

--- a/examples/basic_tokio_async.rs
+++ b/examples/basic_tokio_async.rs
@@ -1,6 +1,6 @@
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, generic_associated_types)]
 
-use xtra::{Actor, Context, Handler, Message};
+use xtra::{Actor, Context, Handler, Message, AsyncHandler};
 use futures::Future;
 
 struct Printer {
@@ -20,11 +20,11 @@ impl Message for Print {
     type Result = ();
 }
 
-impl<'a> Handler<'a, Print> for Printer {
-    type Responder = impl Future<Output = ()> + 'a;
+impl AsyncHandler<Print> for Printer {
+    type Responder<'a> = impl Future<Output = ()> + 'a;
 
-    fn handle(&'a mut self, print: Print, _ctx: &'a mut Context<Self>) -> Self::Responder {
-        async {
+    fn handle<'a>(&'a mut self, print: Print, _ctx: &'a mut Context<Self>) -> Self::Responder<'a> {
+        async move {
             self.times += 1;
             println!("Printing {}. Printed {} times so far.", print.0, self.times);
         }

--- a/examples/basic_tokio_async.rs
+++ b/examples/basic_tokio_async.rs
@@ -20,13 +20,14 @@ impl Message for Print {
     type Result = ();
 }
 
-impl Handler<Print> for Printer {
-    type Responder = impl Future<Output = ()>;
+impl<'a> Handler<'a, Print> for Printer {
+    type Responder = impl Future<Output = ()> + 'a;
 
-    fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> Self::Responder {
-        self.times += 1;
-        println!("Printing {}. Printed {} times so far.", print.0, self.times);
-        futures::future::ready(())
+    fn handle(&'a mut self, print: Print, _ctx: &'a mut Context<Self>) -> Self::Responder {
+        async {
+            self.times += 1;
+            println!("Printing {}. Printed {} times so far.", print.0, self.times);
+        }
     }
 }
 

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -37,7 +37,7 @@ impl Handler<GetCount> for Counter {
 
 #[tokio::main]
 async fn main() {
-    const COUNT: usize = 100_000_000; // May take a while on some machines
+    const COUNT: usize = 50_000_000; // May take a while on some machines
 
     let addr = Counter { count: 0 }.spawn();
 
@@ -51,7 +51,7 @@ async fn main() {
 
     let duration = Instant::now() - start;
 
-    let average_ns = duration.as_nanos() / total_count as u128; // About 200ns on mine
+    let average_ns = duration.as_nanos() / total_count as u128; // <200ns on my machine
 
     println!("avg time: {}ns", average_ns);
 }

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -1,8 +1,8 @@
 #![feature(generic_associated_types, type_alias_impl_trait)]
 
-use xtra::{Actor, Context, Handler, Message, AsyncHandler};
-use std::time::Instant;
 use futures::Future;
+use std::time::Instant;
+use xtra::{Actor, AsyncHandler, Context, Handler, Message};
 
 struct Counter {
     count: usize,

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -1,3 +1,5 @@
+#![feature(type_alias_impl_trait)]
+
 use xtra::{Actor, Context, Handler, Message};
 use std::time::Instant;
 
@@ -50,8 +52,6 @@ async fn main() {
     let total_count = addr.send(GetCount).await.unwrap();
 
     let duration = Instant::now() - start;
-
     let average_ns = duration.as_nanos() / total_count as u128; // <200ns on my machine
-
-    println!("avg time: {}ns", average_ns);
+    println!("davg time: {}ns", average_ns);
 }

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -1,0 +1,57 @@
+use xtra::{Actor, Context, Handler, Message};
+use std::time::Instant;
+
+struct Counter {
+    count: usize,
+}
+
+impl Actor for Counter {}
+
+struct Increment;
+
+impl Message for Increment {
+    type Result = ();
+}
+
+struct GetCount;
+
+impl Message for GetCount {
+    type Result = usize;
+}
+
+impl Handler<Increment> for Counter {
+    type Responder = ();
+
+    fn handle(&mut self, _: Increment, _ctx: &mut Context<Self>) {
+        self.count += 1;
+    }
+}
+
+impl Handler<GetCount> for Counter {
+    type Responder = usize;
+
+    fn handle(&mut self, _: GetCount, _ctx: &mut Context<Self>) -> usize {
+        self.count
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    const COUNT: usize = 100_000_000; // May take a while on some machines
+
+    let addr = Counter { count: 0 }.spawn();
+
+    let start = Instant::now();
+    for _ in 0..COUNT {
+        let _ = addr.do_send(Increment);
+    }
+
+    // awaiting on GetCount will make sure all previous messages are processed first
+    let total_count = addr.send(GetCount).await.unwrap();
+
+    let duration = Instant::now() - start;
+
+    let average_ns = duration.as_nanos() / total_count as u128; // About 200ns on mine
+
+    println!("avg time: {}ns", average_ns);
+}

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,4 +1,4 @@
-use crate::envelope::{Envelope, NonReturningEnvelope, SyncReturningEnvelope};
+use crate::envelope::{Envelope, NonReturningEnvelope, SyncReturningEnvelope, AsyncReturningEnvelope};
 use crate::{Actor, Handler, Message, SyncResponder};
 use futures::channel::mpsc::UnboundedSender;
 use futures::future::Either;
@@ -34,6 +34,27 @@ impl<A: Actor> Address<A> {
     {
         let t = SyncReturningEnvelope::new(message);
         let envelope: SyncReturningEnvelope<A, M> = t.0;
+        let rx = t.1;
+
+        let res = self
+            .sender
+            .unbounded_send(Box::new(envelope))
+            .map_err(|_| Disconnected);
+
+        match res {
+            Ok(()) => Either::Left(rx.map_err(|_| Disconnected)),
+            Err(e) => Either::Right(futures::future::err(e)),
+        }
+    }
+
+    pub fn send_async<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
+        where
+            M: Message,
+            A: Handler<M>,
+            A::Responder: Future<Output = M::Result> + Send,
+    {
+        let t = AsyncReturningEnvelope::new(message);
+        let envelope: AsyncReturningEnvelope<A, M> = t.0;
         let rx = t.1;
 
         let res = self

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,0 +1,53 @@
+use crate::envelope::{Envelope, NonReturningEnvelope, SyncReturningEnvelope};
+use crate::{Actor, Handler, Message, SyncResponder};
+use futures::channel::mpsc::UnboundedSender;
+use futures::future::Either;
+use futures::{Future, TryFutureExt};
+
+/// An `Address` is a reference to an actor through which [`Message`](struct.Message.html)s can be
+/// sent. It can be cloned, and when all `Address`es are dropped, the actor will be stopped. It is
+/// created by calling the [`Actor::start`](trait.Actor.html#method.start) or
+/// [`Actor::spawn`](trait.Actor.html#method.start) methods.
+#[derive(Clone)]
+pub struct Address<A: Actor> {
+    pub(crate) sender: UnboundedSender<Box<dyn Envelope<Actor = A>>>,
+}
+
+impl<A: Actor> Address<A> {
+    pub fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message,
+        A: Handler<M>,
+    {
+        let envelope = NonReturningEnvelope::new(message);
+        self.sender
+            .unbounded_send(Box::new(envelope))
+            .map_err(|_| Disconnected)
+    }
+
+    // TODO async
+    pub fn send<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
+    where
+        M: Message,
+        A: Handler<M>,
+        A::Responder: SyncResponder<M> + Send,
+    {
+        let t = SyncReturningEnvelope::new(message);
+        let envelope: SyncReturningEnvelope<A, M> = t.0;
+        let rx = t.1;
+
+        let res = self
+            .sender
+            .unbounded_send(Box::new(envelope))
+            .map_err(|_| Disconnected);
+
+        match res {
+            Ok(()) => Either::Left(rx.map_err(|_| Disconnected)),
+            Err(e) => Either::Right(futures::future::err(e)),
+        }
+    }
+}
+
+/// The actor is no longer running and disconnected
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Disconnected;

--- a/src/address.rs
+++ b/src/address.rs
@@ -14,10 +14,10 @@ pub struct Address<A: Actor> {
 }
 
 impl<A: Actor> Address<A> {
-    pub fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
+    pub fn do_send<'a, M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
-        A: Handler<M>,
+        A: Handler<'a, M>,
     {
         let envelope = NonReturningEnvelope::new(message);
         self.sender
@@ -26,10 +26,10 @@ impl<A: Actor> Address<A> {
     }
 
     // TODO async
-    pub fn send<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
+    pub fn send<'a, M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
     where
         M: Message,
-        A: Handler<M>,
+        A: Handler<'a, M>,
         A::Responder: SyncResponder<M> + Send,
     {
         let t = SyncReturningEnvelope::new(message);
@@ -47,10 +47,10 @@ impl<A: Actor> Address<A> {
         }
     }
 
-    pub fn send_async<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
+    pub fn send_async<'a, M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
         where
             M: Message,
-            A: Handler<M>,
+            A: Handler<'a, M>,
             A::Responder: Future<Output = M::Result> + Send,
     {
         let t = AsyncReturningEnvelope::new(message);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,10 +1,8 @@
 use crate::Actor;
 use std::marker::PhantomData;
 
-/// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
-/// management loop. It can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)) or
-/// queue a message to be processed by the actor immediately after it has finished processing the
-/// current message ([`Context::notify`](struct.Context.html#method.notify)).
+/// `Context` is used to signal things to the [`ActorManager`](trait.ActorManager.html)'s
+/// management loop. Currently, it can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)).
 pub struct Context<A: Actor + ?Sized> {
     pub(crate) running: bool,
     phantom: PhantomData<A>, // TODO(weak_address)
@@ -19,10 +17,9 @@ impl<A: Actor + ?Sized> Context<A> {
     }
 
     /// Stop the actor as soon as it has finished processing current message. This will mean that it
-    /// will be dropped, and [`Actor::stopping`](trait.Actor.html#method.stopping) and then
-    /// [`Actor::stopped`](trait.Actor.html#method.stopped) will be called. Any subsequent attempts
-    /// to send messages to this actor will return the [`Disconnected`](struct.Disconnected.html)
-    /// error.
+    /// will be dropped, and [`Actor::stopped`](trait.Actor.html#method.stopped) will be called.
+    /// Any subsequent attempts to send messages to this actor will return the
+    /// [`Disconnected`](struct.Disconnected.html) error.
     pub fn stop(&mut self) {
         self.running = false;
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,6 @@
 use crate::envelope::{Envelope, NonReturningEnvelope};
 use crate::{Actor, Handler, Message};
+use std::marker::PhantomData;
 
 /// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
 /// management loop. It can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)) or
@@ -7,29 +8,31 @@ use crate::{Actor, Handler, Message};
 /// current message ([`Context::notify`](struct.Context.html#method.notify)).
 pub struct Context<A: Actor + ?Sized> {
     pub(crate) running: bool,
-    pub(crate) notifications: Vec<Box<dyn Envelope<Actor = A>>>,
+    phantom: PhantomData<A>,
+    // TODO
 }
 
 impl<A: Actor + ?Sized> Context<A> {
     pub(crate) fn new() -> Self {
         Context {
             running: true,
-            notifications: Vec::new(),
+            phantom: PhantomData,
+//            notifications: Vec::new(),
         }
     }
 
-    /// Send a message to this actor to be processed immediately after it has finished processing
-    /// the current message. An unlimited number of notifications can be queued at one time (but,
-    /// as always, they will only be processed one-by-one). Be aware that this does allocate space
-    /// in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
-    pub fn notify<M>(&mut self, notification: M)
-    where
-        M: Message,
-        A: Handler<M>,
-    {
-        let notification = Box::new(NonReturningEnvelope::new(notification));
-        self.notifications.push(notification);
-    }
+//    /// Send a message to this actor to be processed immediately after it has finished processing
+//    /// the current message. An unlimited number of notifications can be queued at one time (but,
+//    /// as always, they will only be processed one-by-one). Be aware that this does allocate space
+//    /// in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
+//    pub fn notify<M>(&mut self, notification: M)
+//    where
+//        M: Message,
+//        A: Handler<'a, M>,
+//    {
+//        let notification = Box::new(NonReturningEnvelope::new(notification));
+//        self.notifications.push(notification);
+//    }
 
     /// Stop the actor as soon as it has finished processing current message. This will mean that it
     /// will be dropped, and [`Actor::stopping`](trait.Actor.html#method.stopping) and then

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 /// current message ([`Context::notify`](struct.Context.html#method.notify)).
 pub struct Context<A: Actor + ?Sized> {
     pub(crate) running: bool,
-    phantom: PhantomData<A>, // TODO will be used
+    phantom: PhantomData<A>, // TODO(weak_address)
 }
 
 impl<A: Actor + ?Sized> Context<A> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,42 @@
+use crate::envelope::{Envelope, NonReturningEnvelope};
+use crate::{Actor, Handler, Message};
+
+/// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
+/// management loop. It can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)) or
+/// queue a message to be processed by the actor immediately after it has finished processing the
+/// current message ([`Context::notify`](struct.Context.html#method.notify)).
+pub struct Context<A: Actor + ?Sized> {
+    pub(crate) running: bool,
+    pub(crate) notifications: Vec<Box<dyn Envelope<Actor = A>>>,
+}
+
+impl<A: Actor + ?Sized> Context<A> {
+    pub(crate) fn new() -> Self {
+        Context {
+            running: true,
+            notifications: Vec::new(),
+        }
+    }
+
+    /// Send a message to this actor to be processed immediately after it has finished processing
+    /// the current message. An unlimited number of notifications can be queued at one time (but,
+    /// as always, they will only be processed one-by-one). Be aware that this does allocate space
+    /// in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
+    pub fn notify<M>(&mut self, notification: M)
+    where
+        M: Message,
+        A: Handler<M>,
+    {
+        let notification = Box::new(NonReturningEnvelope::new(notification));
+        self.notifications.push(notification);
+    }
+
+    /// Stop the actor as soon as it has finished processing current message. This will mean that it
+    /// will be dropped, and [`Actor::stopping`](trait.Actor.html#method.stopping) and then
+    /// [`Actor::stopped`](trait.Actor.html#method.stopped) will be called. Any subsequent attempts
+    /// to send messages to this actor will return the [`Disconnected`](struct.Disconnected.html)
+    /// error.
+    pub fn stop(&mut self) {
+        self.running = false;
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::{Actor, Handler, Message};
+use crate::Actor;
 use std::marker::PhantomData;
 
 /// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
@@ -15,22 +15,22 @@ impl<A: Actor + ?Sized> Context<A> {
         Context {
             running: true,
             phantom: PhantomData,
-//            notifications: Vec::new(),
+            //            notifications: Vec::new(),
         }
     }
 
-//    /// Send a message to this actor to be processed immediately after it has finished processing
-//    /// the current message. An unlimited number of notifications can be queued at one time (but,
-//    /// as always, they will only be processed one-by-one). Be aware that this does allocate space
-//    /// in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
-//    pub fn notify<M>(&mut self, notification: M)
-//    where
-//        M: Message,
-//        A: Handler<'a, M>,
-//    {
-//        let notification = Box::new(NonReturningEnvelope::new(notification));
-//        self.notifications.push(notification);
-//    }
+    //    /// Send a message to this actor to be processed immediately after it has finished processing
+    //    /// the current message. An unlimited number of notifications can be queued at one time (but,
+    //    /// as always, they will only be processed one-by-one). Be aware that this does allocate space
+    //    /// in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
+    //    pub fn notify<M>(&mut self, notification: M)
+    //    where
+    //        M: Message,
+    //        A: Handler<'a, M>,
+    //    {
+    //        let notification = Box::new(NonReturningEnvelope::new(notification));
+    //        self.notifications.push(notification);
+    //    }
 
     /// Stop the actor as soon as it has finished processing current message. This will mean that it
     /// will be dropped, and [`Actor::stopping`](trait.Actor.html#method.stopping) and then

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,3 @@
-use crate::envelope::{Envelope, NonReturningEnvelope};
 use crate::{Actor, Handler, Message};
 use std::marker::PhantomData;
 
@@ -8,8 +7,7 @@ use std::marker::PhantomData;
 /// current message ([`Context::notify`](struct.Context.html#method.notify)).
 pub struct Context<A: Actor + ?Sized> {
     pub(crate) running: bool,
-    phantom: PhantomData<A>,
-    // TODO
+    phantom: PhantomData<A>, // TODO will be used
 }
 
 impl<A: Actor + ?Sized> Context<A> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,22 +15,8 @@ impl<A: Actor + ?Sized> Context<A> {
         Context {
             running: true,
             phantom: PhantomData,
-            //            notifications: Vec::new(),
         }
     }
-
-    //    /// Send a message to this actor to be processed immediately after it has finished processing
-    //    /// the current message. An unlimited number of notifications can be queued at one time (but,
-    //    /// as always, they will only be processed one-by-one). Be aware that this does allocate space
-    //    /// in a [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
-    //    pub fn notify<M>(&mut self, notification: M)
-    //    where
-    //        M: Message,
-    //        A: Handler<'a, M>,
-    //    {
-    //        let notification = Box::new(NonReturningEnvelope::new(notification));
-    //        self.notifications.push(notification);
-    //    }
 
     /// Stop the actor as soon as it has finished processing current message. This will mean that it
     /// will be dropped, and [`Actor::stopping`](trait.Actor.html#method.stopping) and then

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -9,6 +9,15 @@ type Fut<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 pub(crate) trait Envelope: Send {
     type Actor: Actor + ?Sized;
 
+    // We could return some enum like:
+    //
+    // enum Return<'a> {
+    //     Fut(Fut<'a>),
+    //     Noop,
+    // }
+    //
+    // But this is actually about 10% *slower* for `do_send`. I don't know why. Maybe something to
+    // do with branch [mis]prediction or compiler optimisation
     fn handle<'a, 'c>(
         &'a mut self,
         act: &'a mut Self::Actor,

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,0 +1,119 @@
+use crate::{Actor, Context, Handler, Message, SyncResponder};
+use futures::channel::oneshot::{self, Receiver, Sender};
+use futures::{future, Future, FutureExt};
+use std::marker::PhantomData;
+
+type Fut<'a> = Box<dyn Future<Output = ()> + Unpin + Send + 'a>;
+
+pub(crate) trait Envelope: Send {
+    type Actor: Actor + ?Sized;
+
+    fn handle<'a, 'c>(
+        &'a mut self,
+        act: &'a mut Self::Actor,
+        ctx: &'a mut Context<Self::Actor>,
+    ) -> Fut<'a>;
+}
+
+pub(crate) struct SyncReturningEnvelope<A: Actor + ?Sized + Handler<M>, M: Message> {
+    message: Option<M>, // Options so that we can opt.take()
+    result_sender: Option<Sender<M::Result>>,
+    phantom: PhantomData<A>,
+}
+
+impl<A: Actor + ?Sized + Handler<M>, M: Message> SyncReturningEnvelope<A, M> {
+    pub(crate) fn new(message: M) -> (Self, Receiver<M::Result>) {
+        let (tx, rx) = oneshot::channel();
+        let envelope = SyncReturningEnvelope {
+            message: Some(message),
+            result_sender: Some(tx),
+            phantom: PhantomData,
+        };
+
+        (envelope, rx)
+    }
+}
+
+impl<A: Actor + Handler<M>, M: Message> Envelope for SyncReturningEnvelope<A, M>
+where
+    A::Responder: Send,
+    A::Responder: SyncResponder<M>,
+{
+    type Actor = A;
+
+    fn handle(
+        &mut self,
+        act: &mut Self::Actor,
+        ctx: &mut Context<Self::Actor>,
+    ) -> Fut {
+        let message_result = act.handle(self.message.take().expect("Message must be Some"), ctx);
+
+        // We don't actually care if the receiver is listening
+        let _ = self
+            .result_sender
+            .take()
+            .expect("Sender must be Some")
+            .send(message_result.cast());
+
+        Box::new(future::ready(()))
+    }
+}
+
+pub(crate) struct AsyncReturningEnvelope<A: Actor + ?Sized + Handler<M>, M: Message> {
+    message: Option<M>, // Options so that we can opt.take()
+    result_sender: Option<Sender<M::Result>>,
+    phantom: PhantomData<A>,
+}
+
+impl<A: Actor + Handler<M>, M: Message> Envelope for AsyncReturningEnvelope<A, M>
+where
+    A::Responder: Send,
+    A::Responder: Future<Output = M::Result>,
+{
+    type Actor = A;
+
+    fn handle<'a>(
+        &'a mut self,
+        act: &'a mut Self::Actor,
+        ctx: &'a mut Context<Self::Actor>,
+    ) -> Fut {
+        Box::new(
+            act.handle(self.message.take().expect("Message must be Some"), ctx)
+                .map(move |r| {
+                    // We don't actually care if the receiver is listening
+                    let _ = self
+                        .result_sender
+                        .take()
+                        .expect("Sender must be Some")
+                        .send(r);
+                }),
+        )
+    }
+}
+
+pub(crate) struct NonReturningEnvelope<A: Actor + ?Sized, M: Message> {
+    message: Option<M>, // Option so that we can opt.take()
+    phantom: PhantomData<A>,
+}
+
+impl<A: Actor + ?Sized, M: Message> NonReturningEnvelope<A, M> {
+    pub(crate) fn new(message: M) -> Self {
+        NonReturningEnvelope {
+            message: Some(message),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A: Actor + Handler<M> + ?Sized, M: Message> Envelope for NonReturningEnvelope<A, M> {
+    type Actor = A;
+
+    fn handle(
+        &mut self,
+        act: &mut Self::Actor,
+        ctx: &mut Context<Self::Actor>,
+    ) -> Fut {
+        act.handle(self.message.take().expect("Message must be Some"), ctx);
+        Box::new(future::ready(()))
+    }
+}

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -6,7 +6,6 @@ use std::pin::Pin;
 
 type Fut<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
-// TODO Nick12 ISSUE: this CAN'T have 'a because i need to construct dyn Envelope<'a>
 pub(crate) trait Envelope: Send {
     type Actor: Actor + ?Sized;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl<M: Message> SyncResponder<M> for M::Result {
 /// and the logic to handle the message.
 pub trait Handler<M: Message>: Actor {
     // TODO doc
-    type Responder: MessageResponder<M>;
+    type Responder;
 
     /// Handle a given message, returning its result.
     fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> Self::Responder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub trait Message: Send + 'static {
 /// synchronously, and the logic to handle the message.
 pub trait Handler<M: Message>: Actor {
     /// Handle a given message, returning its result.
-    fn handle(&mut self, message: M, ctx:  &mut Context<Self>) -> M::Result;
+    fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> M::Result;
 }
 
 /// A trait indicating that an [`Actor`](struct.Actor.html) can handle a given [`Message`](trait.Message.html)
@@ -56,6 +56,7 @@ pub trait Actor: Send + 'static {
     /// is dropped.
     fn stopped(&mut self, _ctx: &mut Context<Self>) {}
 
+    #[cfg(any(feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     fn spawn(self) -> Address<Self>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![feature(specialization)]
+
+#[macro_use]
+extern crate rental;
+
 mod envelope;
 
 mod address;
@@ -34,12 +39,12 @@ impl<M: Message> SyncResponder<M> for M::Result {
 
 /// A trait indicating that an [`Actor`](struct.Actor.html) can handle a given [`Message`](trait.Message.html),
 /// and the logic to handle the message.
-pub trait Handler<M: Message>: Actor {
+pub trait Handler<'a, M: Message>: Actor {
     // TODO doc
-    type Responder;
+    type Responder: 'a;
 
     /// Handle a given message, returning its result.
-    fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> Self::Responder;
+    fn handle(&'a mut self, message: M, ctx: &'a mut Context<Self>) -> Self::Responder;
 }
 
 pub trait Actor: Send + 'static {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,65 @@
-//! Adapted from actix `address` module
+mod envelope;
 
-use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use futures::channel::oneshot::{self, Receiver, Sender};
-use futures::future::Either;
-use futures::TryFutureExt;
-use futures::{Future, StreamExt};
-use std::boxed::Box;
-use std::marker::PhantomData;
+mod address;
+pub use address::{Address, Disconnected};
 
+mod context;
+pub use context::Context;
+
+mod manager;
+pub use manager::ActorManager;
+
+/// A message that can be sent to an [`Actor`](struct.Actor.html) for processing. They are processed
+/// one at a time. Only actors implementing the corresponding [`Handler<M>`](trait.Handler.html)
+/// trait can be sent a given message.
 pub trait Message: Send + 'static {
-    type Result: Send;
+    /// The return type of the message. It will be returned when the [`Address::send`](struct.Address.html#method.send)
+    /// is called.
+    type Result: Send + Unpin;
 }
 
+pub trait MessageResponder<M: Message>: Unpin {}
+
+impl<M: Message> MessageResponder<M> for M::Result {}
+
+pub trait SyncResponder<M: Message>: MessageResponder<M> {
+    fn cast(self) -> M::Result;
+}
+
+impl<M: Message> SyncResponder<M> for M::Result {
+    fn cast(self) -> M::Result {
+        self
+    }
+}
+
+/// A trait indicating that an [`Actor`](struct.Actor.html) can handle a given [`Message`](trait.Message.html),
+/// and the logic to handle the message.
 pub trait Handler<M: Message>: Actor {
-    fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> M::Result;
+    // TODO doc
+    type Responder: MessageResponder<M>;
+
+    /// Handle a given message, returning its result.
+    fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> Self::Responder;
 }
 
-pub trait Actor: Send + Unpin + 'static {
+pub trait Actor: Send + 'static {
+    /// Called as soon as the actor has been started.
     fn started(&mut self, _ctx: &mut Context<Self>) {}
-    fn stopping(&mut self, _ctx: &mut Context<Self>) {}
-    fn stopped(&mut self) {}
 
-    #[cfg(feature = "tokio_spawn")]
+    /// Called when the actor is in the process of stopping. The key difference between this method
+    /// and [`Actor::stopped`](trait.Actor.html#method.stopped) is that the actor can prevent itself
+    /// from stopping by returning [`KeepRunning::Yes`](enum.KeepRunning.html#variant.Yes) from this
+    /// function.
+    fn stopping(&mut self, _ctx: &mut Context<Self>) -> KeepRunning {
+        KeepRunning::No
+    }
+
+    /// Called when the actor is in the process of stopping. The key difference between this method
+    /// and [`Actor::stopping`](trait.Actor.html#method.stopping) is that the actor cannot be rescued
+    /// from being stopped at this stage. This should be used for any final cleanup before the actor
+    /// is dropped.
+    fn stopped(&mut self, _ctx: &mut Context<Self>) {}
+
     fn spawn(self) -> Address<Self>
     where
         Self: Sized,
@@ -37,188 +75,10 @@ pub trait Actor: Send + Unpin + 'static {
     }
 }
 
-pub struct Context<A: Actor + ?Sized> {
-    running: bool,
-    notifications: Vec<Box<dyn Envelope<Actor = A>>>,
-}
-
-impl<A: Actor + ?Sized> Context<A> {
-    fn new() -> Self {
-        Context {
-            running: true,
-            notifications: Vec::with_capacity(1),
-        }
-    }
-
-    pub fn notify<M>(&mut self, notification: M)
-    where
-        M: Message,
-        A: Handler<M>,
-    {
-        let notification = Box::new(NonReturningEnvelope::new(notification));
-        self.notifications.push(notification);
-    }
-
-    pub fn stop(&mut self) {
-        self.running = false;
-    }
-}
-
-trait Envelope: Send {
-    type Actor: Actor + ?Sized;
-
-    fn handle(&mut self, act: &mut Self::Actor, ctx: &mut Context<Self::Actor>);
-}
-
-struct ReturningEnvelope<A: Actor + ?Sized, M: Message> {
-    message: Option<M>, // Options so that we can opt.take()
-    result_sender: Option<Sender<M::Result>>,
-    phantom: PhantomData<A>,
-}
-
-impl<A: Actor + ?Sized, M: Message> ReturningEnvelope<A, M> {
-    fn new(message: M) -> (Self, Receiver<M::Result>) {
-        let (tx, rx) = oneshot::channel();
-        let envelope = ReturningEnvelope {
-            message: Some(message),
-            result_sender: Some(tx),
-            phantom: PhantomData,
-        };
-
-        (envelope, rx)
-    }
-}
-
-impl<A: Actor + Handler<M>, M: Message> Envelope for ReturningEnvelope<A, M> {
-    type Actor = A;
-
-    fn handle(&mut self, act: &mut Self::Actor, ctx: &mut Context<Self::Actor>) {
-        let message_result = act.handle(self.message.take().expect("Message must be Some"), ctx);
-
-        // We don't actually care if the receiver is listening
-        let _ = self
-            .result_sender
-            .take()
-            .expect("Sender must be Some")
-            .send(message_result);
-    }
-}
-
-struct NonReturningEnvelope<A: Actor + ?Sized, M: Message> {
-    message: Option<M>, // Option so that we can opt.take()
-    phantom: PhantomData<A>,
-}
-
-impl<A: Actor + ?Sized, M: Message> NonReturningEnvelope<A, M> {
-    fn new(message: M) -> Self {
-        NonReturningEnvelope {
-            message: Some(message),
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<A: Actor + Handler<M> + ?Sized, M: Message> Envelope for NonReturningEnvelope<A, M> {
-    type Actor = A;
-
-    fn handle(&mut self, act: &mut Self::Actor, ctx: &mut Context<Self::Actor>) {
-        act.handle(self.message.take().expect("Message must be Some"), ctx);
-    }
-}
-
-#[derive(Clone)]
-pub struct Address<A: Actor> {
-    sender: UnboundedSender<Box<dyn Envelope<Actor = A>>>,
-}
-
-impl<A: Actor> Address<A> {
-    pub fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
-    where
-        M: Message,
-        A: Handler<M>,
-    {
-        let envelope = NonReturningEnvelope::new(message);
-        self.sender
-            .unbounded_send(Box::new(envelope))
-            .map_err(|_| Disconnected)
-    }
-
-    pub fn send<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
-    where
-        M: Message,
-        A: Handler<M>,
-    {
-        let (envelope, rx) = ReturningEnvelope::new(message);
-
-        let res = self
-            .sender
-            .unbounded_send(Box::new(envelope))
-            .map_err(|_| Disconnected);
-
-        match res {
-            Ok(()) => Either::Left(rx.map_err(|_| Disconnected)),
-            Err(e) => Either::Right(futures::future::err(e)),
-        }
-    }
-}
-
-/// The actor is no longer running and disconnected
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct Disconnected;
-
-pub struct ActorManager<A: Actor + Unpin + 'static> {
-    receiver: UnboundedReceiver<Box<dyn Envelope<Actor = A>>>,
-    actor: A,
-    ctx: Context<A>,
-}
-
-impl<A: Actor + 'static + Unpin> Drop for ActorManager<A> {
-    fn drop(&mut self) {
-        self.actor.stopping(&mut self.ctx);
-
-        // Handle notifications (messages to self)
-        while let Some(mut notif) = self.ctx.notifications.pop() {
-            notif.handle(&mut self.actor, &mut self.ctx);
-        }
-
-        self.actor.stopped();
-    }
-}
-
-impl<A: Actor + 'static + Unpin> ActorManager<A> {
-    #[cfg(feature = "tokio_spawn")]
-    fn spawn(actor: A) -> Address<A> {
-        let (addr, mgr) = Self::start(actor);
-        tokio::spawn(mgr.manage());
-        addr
-    }
-
-    fn start(actor: A) -> (Address<A>, ActorManager<A>) {
-        let (sender, receiver) = mpsc::unbounded();
-        let ctx = Context::new();
-        let mgr = ActorManager {
-            receiver,
-            actor,
-            ctx,
-        };
-        let addr = Address { sender };
-
-        (addr, mgr)
-    }
-
-    pub async fn manage(mut self) {
-        while let Some(mut msg) = self.receiver.next().await {
-            msg.handle(&mut self.actor, &mut self.ctx);
-
-            // Check if the context was stopped
-            if !self.ctx.running {
-                return;
-            }
-
-            // Handle notifications (messages to self)
-            while let Some(mut notif) = self.ctx.notifications.pop() {
-                notif.handle(&mut self.actor, &mut self.ctx);
-            }
-        }
-    }
+/// Whether to keep the actor running after [`Context::stop`](struct.Context.html#method.stop) has
+/// been called, or all the [`Address`es](struct.Address.html) to an actor have been dropped.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KeepRunning {
+    Yes,
+    No,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@ pub use manager::ActorManager;
 pub trait Message: Send + 'static {
     /// The return type of the message. It will be returned when the [`Address::send`](struct.Address.html#method.send)
     /// is called.
-    type Result: Send + Unpin;
+    type Result: Send;
 }
 
-pub trait MessageResponder<M: Message>: Unpin {}
+pub trait MessageResponder<M: Message> {}
 
 impl<M: Message> MessageResponder<M> for M::Result {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![feature(generic_associated_types)]
 
-#[macro_use]
-extern crate rental;
-
 mod envelope;
 
 mod address;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,74 @@
+use crate::envelope::Envelope;
+use crate::{Actor, Address, Context, KeepRunning};
+use futures::channel::mpsc::{self, UnboundedReceiver};
+use futures::StreamExt;
+
+pub struct ActorManager<A: Actor> {
+    receiver: UnboundedReceiver<Box<dyn Envelope<Actor = A>>>,
+    //    sender: UnboundedSender<Box<dyn Envelope<Actor = A>>>, // TODO
+    actor: A,
+    ctx: Context<A>,
+}
+
+impl<A: Actor> Drop for ActorManager<A> {
+    fn drop(&mut self) {
+        self.actor.stopped(&mut self.ctx);
+    }
+}
+
+impl<A: Actor> ActorManager<A> {
+    pub(crate) fn spawn(actor: A) -> Address<A> {
+        let (addr, mgr) = Self::start(actor);
+
+        #[cfg(feature = "with-tokio-0_2")]
+        tokio::spawn(mgr.manage());
+
+        #[cfg(feature = "with-async_std-1")]
+        async_std::task::spawn(mgr.manage());
+
+        addr
+    }
+
+    pub(crate) fn start(actor: A) -> (Address<A>, ActorManager<A>) {
+        let (sender, receiver) = mpsc::unbounded();
+        let ctx = Context::new();
+        let mgr = ActorManager {
+            receiver,
+            actor,
+            ctx,
+        };
+        let addr = Address { sender };
+
+        (addr, mgr)
+    }
+
+    /// Handle notifications (messages to self)
+    async fn handle_notifications(&mut self) {
+        while let Some(mut notif) = self.ctx.notifications.pop() {
+            notif.handle(&mut self.actor, &mut self.ctx).await;
+        }
+    }
+
+    pub async fn manage(mut self) {
+        self.actor.started(&mut self.ctx);
+
+        while let Some(mut msg) = self.receiver.next().await {
+            msg.handle(&mut self.actor, &mut self.ctx).await;
+
+            // Check if the context was stopped
+            if !self.ctx.running {
+                return;
+            }
+
+            // Handle notifications (messages to self)
+            while let Some(mut notif) = self.ctx.notifications.pop() {
+                notif.handle(&mut self.actor, &mut self.ctx).await;
+            }
+        }
+
+        // TODO
+        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
+            self.handle_notifications().await
+        }
+    }
+}

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,7 +5,6 @@ use futures::StreamExt;
 
 pub struct ActorManager<A: Actor> {
     receiver: UnboundedReceiver<Box<dyn Envelope<Actor = A>>>,
-    //    sender: UnboundedSender<Box<dyn Envelope<Actor = A>>>, // TODO
     actor: A,
     ctx: Context<A>,
 }
@@ -67,7 +66,7 @@ impl<A: Actor> ActorManager<A> {
             //            }
         }
 
-        //        // TODO
+        //        // TODO(weak_address)
         //        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
         //            self.handle_notifications().await
         //        }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::envelope::Envelope;
-use crate::{Actor, Address, Context, KeepRunning};
+use crate::{Actor, Address, Context};
 use futures::channel::mpsc::{self, UnboundedReceiver};
 use futures::StreamExt;
 
@@ -17,6 +17,7 @@ impl<A: Actor> Drop for ActorManager<A> {
 }
 
 impl<A: Actor> ActorManager<A> {
+    #[cfg(any(feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     pub(crate) fn spawn(actor: A) -> Address<A> {
         let (addr, mgr) = Self::start(actor);
 
@@ -42,12 +43,12 @@ impl<A: Actor> ActorManager<A> {
         (addr, mgr)
     }
 
-//    /// Handle notifications (messages to self)
-//    async fn handle_notifications(&mut self) {
-//        while let Some(mut notif) = self.ctx.notifications.pop() {
-//            notif.handle(&mut self.actor, &mut self.ctx).await;
-//        }
-//    }
+    //    /// Handle notifications (messages to self)
+    //    async fn handle_notifications(&mut self) {
+    //        while let Some(mut notif) = self.ctx.notifications.pop() {
+    //            notif.handle(&mut self.actor, &mut self.ctx).await;
+    //        }
+    //    }
 
     pub async fn manage(mut self) {
         self.actor.started(&mut self.ctx);
@@ -59,16 +60,16 @@ impl<A: Actor> ActorManager<A> {
             if !self.ctx.running {
                 return;
             }
-//
-//            // Handle notifications (messages to self)
-//            while let Some(mut notif) = self.ctx.notifications.pop() {
-//                notif.handle(&mut self.actor, &mut self.ctx).await;
-//            }
+            //
+            //            // Handle notifications (messages to self)
+            //            while let Some(mut notif) = self.ctx.notifications.pop() {
+            //                notif.handle(&mut self.actor, &mut self.ctx).await;
+            //            }
         }
 
-//        // TODO
-//        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
-//            self.handle_notifications().await
-//        }
+        //        // TODO
+        //        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
+        //            self.handle_notifications().await
+        //        }
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -42,12 +42,12 @@ impl<A: Actor> ActorManager<A> {
         (addr, mgr)
     }
 
-    /// Handle notifications (messages to self)
-    async fn handle_notifications(&mut self) {
-        while let Some(mut notif) = self.ctx.notifications.pop() {
-            notif.handle(&mut self.actor, &mut self.ctx).await;
-        }
-    }
+//    /// Handle notifications (messages to self)
+//    async fn handle_notifications(&mut self) {
+//        while let Some(mut notif) = self.ctx.notifications.pop() {
+//            notif.handle(&mut self.actor, &mut self.ctx).await;
+//        }
+//    }
 
     pub async fn manage(mut self) {
         self.actor.started(&mut self.ctx);
@@ -59,16 +59,16 @@ impl<A: Actor> ActorManager<A> {
             if !self.ctx.running {
                 return;
             }
-
-            // Handle notifications (messages to self)
-            while let Some(mut notif) = self.ctx.notifications.pop() {
-                notif.handle(&mut self.actor, &mut self.ctx).await;
-            }
+//
+//            // Handle notifications (messages to self)
+//            while let Some(mut notif) = self.ctx.notifications.pop() {
+//                notif.handle(&mut self.actor, &mut self.ctx).await;
+//            }
         }
 
-        // TODO
-        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
-            self.handle_notifications().await
-        }
+//        // TODO
+//        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
+//            self.handle_notifications().await
+//        }
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -42,13 +42,6 @@ impl<A: Actor> ActorManager<A> {
         (addr, mgr)
     }
 
-    //    /// Handle notifications (messages to self)
-    //    async fn handle_notifications(&mut self) {
-    //        while let Some(mut notif) = self.ctx.notifications.pop() {
-    //            notif.handle(&mut self.actor, &mut self.ctx).await;
-    //        }
-    //    }
-
     pub async fn manage(mut self) {
         self.actor.started(&mut self.ctx);
 
@@ -59,16 +52,6 @@ impl<A: Actor> ActorManager<A> {
             if !self.ctx.running {
                 return;
             }
-            //
-            //            // Handle notifications (messages to self)
-            //            while let Some(mut notif) = self.ctx.notifications.pop() {
-            //                notif.handle(&mut self.actor, &mut self.ctx).await;
-            //            }
         }
-
-        //        // TODO(weak_address)
-        //        if self.actor.stopping(&mut self.ctx) == KeepRunning::Yes {
-        //            self.handle_notifications().await
-        //        }
     }
 }


### PR DESCRIPTION
- Adds `AsyncHandler` trait for handling messages asynchronously
- Adds `do_send_async` and `send_async` for sending messages that should be handled asynchronous
- Added some documentation (unfinished)
- Unresolved question (issue will be open): should we drop the synchronous `Handler` trait altogether to streamline the code and interface? This would mean that synchronous responders would be ~5% slower (according to my benchmarks).