### PR TITLE
Weak addresses and various notifications

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,0 +1,10 @@
+# Breaking Changes by Version
+
+## 0.2.0
+
+- Removal of the `with-runtime` feature
+    - *How to upgrade:* You probably weren't using this anyway, but rather use `with-tokio-*` or `with-async_std-*`
+    instead.
+- `Actor::stopped` does not take `&mut Context` any longer
+    - *How to upgrade:* move stopping code that requires `Context` to `Actor::stopping`
+- `Address` methods were moved to `AddressExt` to accommodate new `Address` types

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -8,5 +8,7 @@
 - `Address` methods were moved to `AddressExt` to accommodate new `Address` types
     - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 
     `use xtra::prelude::*`)
-- `Address::send` and `Address::send_async` now return `MessageResponseFuture` instead of the equivalently-typed
-  `impl Future`. I'm not sure if this is breaking, so I'll put it here anyway.
+- All `*_async` methods were removed. Asynchronous and synchronous messages now use the same method for everything.
+    - *How to upgrade:* simply switch from the `[x]_async` method to the `[x]` method.
+- `AsyncHandler` was renamed to `Handler`, and the old `Handler` to `SyncHandler`. Also, a `Handler` and `SyncHandler` implementation can no longer coexist.
+    - *How to upgrade:* rename all `Handler` implementations to `SyncHandler`, and all `AsyncHandler` implementations to `Handler`.

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -5,6 +5,6 @@
 - Removal of the `with-runtime` feature
     - *How to upgrade:* You probably weren't using this anyway, but rather use `with-tokio-*` or `with-async_std-*`
     instead.
-- `Actor::stopped` does not take `&mut Context` any longer
-    - *How to upgrade:* move stopping code that requires `Context` to `Actor::stopping`
 - `Address` methods were moved to `AddressExt` to accommodate new `Address` types
+    - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 
+    `use xtra::prelude::*`)

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -8,3 +8,5 @@
 - `Address` methods were moved to `AddressExt` to accommodate new `Address` types
     - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 
     `use xtra::prelude::*`)
+- `Address::send` and `Address::send_async` now return `MessageResponseFuture` instead of the equivalently-typed
+  `impl Future`. I'm not sure if this is breaking, so I'll put it here anyway.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtra"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 description = "A tiny actor framework"
 authors = ["Restioson <restiosondev@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtra"
-version = "0.2.0"
+version = "0.2.0-rc.1"
 description = "A tiny actor framework"
 authors = ["Restioson <restiosondev@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ async fn main() {
 }
 ```
 
+For a longer example, check out [Vertex](https://github.com/Restioson/vertex/tree/room-persistence), a chat application
+written with xtra (on the server).
+
 ## Okay, sounds great! How do I use it?
 Check out the [docs](https://docs.rs/xtra) and the [examples](https://github.com/Restioson/xtra/blob/master/examples)
 to get started! Enabling the `with-tokio-0_2` or `with-async_std-1` features are recommended in order to enable some 

--- a/README.md
+++ b/README.md
@@ -90,5 +90,3 @@ See the full list of breaking changes by version [here](https://github.com/Resti
 
 ## To do
 - Examples in documentation
-- Actor notifications (sending messages to self) and creating an address from the actor's context
-- Scheduling of repeated-at-interval and time-delayed messages for actors

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ convenience methods (such as `Actor::spawn`). Which you enable will depend on wh
 their docs to learn more about each). If you have any questions, feel free to [open an issue](https://github.com/Restioson/xtra/issues/new)
 or message me on the [Rust discord](https://bit.ly/rust-community).
 
+## Latest Breaking Changes
+From version 0.1.x to 0.2.0:
+- Removal of the `with-runtime` feature
+    - *How to upgrade:* You probably weren't using this anyway, but rather use `with-tokio-*` or `with-async_std-*`
+    instead.
+- `Address` methods were moved to `AddressExt` to accommodate new `Address` types
+    - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 
+    `use xtra::prelude::*`).
+    
+See the full list of breaking changes by version [here](https://github.com/Restioson/xtra/blob/master/BREAKING-CHANGES.md)
+
 ## To do
 - Thread-local actors that are `!Send`
 - Examples in documentation

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ From version 0.1.x to 0.2.0:
 - `Address` methods were moved to `AddressExt` to accommodate new `Address` types
     - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 
     `use xtra::prelude::*`).
-    
+- `Address::send` and `Address::send_async` now return `MessageResponseFuture` instead of the equivalently-typed
+  `impl Future`. I'm not sure if this is breaking, so I'll put it here anyway.
+
 See the full list of breaking changes by version [here](https://github.com/Restioson/xtra/blob/master/BREAKING-CHANGES.md)
 
 ## To do

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A tiny, fast, and safe actor framework. It is modelled around Actix (copyright and license [here](https://github.com/Restioson/xtra/blob/master/LICENSE-ACTIX)).
 
 ## Features
-- Safe: there is no unsafe code in `xtra` (there is some necessary in `futures`, but that's par for the course).
+- Safe: there is no unsafe code in xtra (there is some necessary in `futures`, but that's par for the course).
 - Small and lightweight: it only depends on `futures` by default.
 - Asynchronous and synchronous message handlers.
 - Simple asynchronous message handling interface which allows `async`/`await` syntax. No more `ActorFuture` and 
@@ -47,6 +47,7 @@ impl Message for Print {
     type Result = ();
 }
 
+// In the real world, the synchronous Handler trait would be better-suited (and is a few ns faster)
 impl AsyncHandler<Print> for Printer {
     type Responder<'a> = impl Future<Output = ()> + 'a;
 
@@ -90,6 +91,6 @@ See the full list of breaking changes by version [here](https://github.com/Resti
 ## To do
 - Thread-local actors that are `!Send`
 - Examples in documentation
+- More internal documentation
 - Actor notifications (sending messages to self) and creating an address from the actor's context
 - Scheduling of repeated-at-interval and time-delayed messages for actors
-

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ From version 0.1.x to 0.2.0:
 See the full list of breaking changes by version [here](https://github.com/Restioson/xtra/blob/master/BREAKING-CHANGES.md)
 
 ## To do
-- Thread-local actors that are `!Send`
 - Examples in documentation
-- More internal documentation
 - Actor notifications (sending messages to self) and creating an address from the actor's context
 - Scheduling of repeated-at-interval and time-delayed messages for actors

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A tiny, fast, and safe actor framework. It is modelled around Actix (copyright a
 laborious combinators - asynchronous responders just return `impl Future`, even when borrowing `self`.
 - Does not depend on its own runtime and can be run with any futures executor ([Tokio](https://tokio.rs/) and 
 [async-std](https://async.rs/) have the `Actor::spawn` convenience method implemented out of the box).
-- Quite fast (<170ns time from sending a message to it being processed for sending without waiting for a result on my
-development machine with an AMD Ryzen 3 3200G)
+- Quite fast (under Tokio, <170ns time from sending a message to it being processed for sending without waiting for a 
+result on my development machine with an AMD Ryzen 3 3200G)
 
 ## Caveats
 - The main caveat of this crate is that it uses many unstable features. For example, to get rid of `ActorFuture`,
@@ -85,8 +85,6 @@ From version 0.1.x to 0.2.0:
 - `Address` methods were moved to `AddressExt` to accommodate new `Address` types
     - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 
     `use xtra::prelude::*`).
-- `Address::send` and `Address::send_async` now return `MessageResponseFuture` instead of the equivalently-typed
-  `impl Future`. I'm not sure if this is breaking, so I'll put it here anyway.
 
 See the full list of breaking changes by version [here](https://github.com/Restioson/xtra/blob/master/BREAKING-CHANGES.md)
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,75 @@
 # xtra
-A tiny (<1k LOC) actor framework. It is modelled around Actix (copyright and license [here](https://github.com/Restioson/xtra/blob/master/LICENSE-ACTIX)). It's probably best to not use this production.
+A tiny, fast, and safe actor framework. It is modelled around Actix (copyright and license [here](https://github.com/Restioson/xtra/blob/master/LICENSE-ACTIX)).
 
 ## Features
+- Safe: there is no unsafe code in `xtra` (there is some necessary in `futures`, but that's par for the course).
 - Small and lightweight: it only depends on `futures` by default.
-- Asynchronous and synchronous responders
-- Simple asynchronous message handling interface which allows `async`/`await` syntax (no more `ActorFuture` - 
-asynchronous responders just return `impl Future`, even when borrowing `self`)
+- Asynchronous and synchronous message handlers.
+- Simple asynchronous message handling interface which allows `async`/`await` syntax. No more `ActorFuture` and 
+laborious combinators - asynchronous responders just return `impl Future`, even when borrowing `self`.
 - Does not depend on its own runtime and can be run with any futures executor ([Tokio](https://tokio.rs/) and 
 [async-std](https://async.rs/) have the `Actor::spawn` convenience method implemented out of the box).
 - Quite fast (<170ns time from sending a message to it being processed for sending without waiting for a result on my
 development machine with an AMD Ryzen 3 3200G)
 
-## Okay, sounds great! How do I use it?
+## Caveats
+- The main caveat of this crate is that it uses many unstable features. For example, to get rid of `ActorFuture`,
+[Generic Associated Types (GATs)](https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md)
+must be used. This is an incomplete and unstable feature, which [appears to be a way off from stabilisation](https://github.com/rust-lang/rust/issues/44265).
+It also uses [`impl Trait` Type Aliases](https://github.com/rust-lang/rfcs/pull/2515) to avoid `Box`ing the futures
+returned from the `AsyncHandler` trait (the library, however, is not totally alloc-free). This means that it requires
+nightly to use, and may be unstable in future as those features evolve. What you get in return for this is a cleaner,
+simpler, and more expressive API. 
+- It is also still very much under development, so it may not be ready for production code.
 
+## Example
+```rust
+#![feature(type_alias_impl_trait, generic_associated_types)]
+
+use futures::Future;
+use xtra::prelude::*;
+
+struct Printer {
+    times: usize,
+}
+
+impl Printer {
+    fn new() -> Self {
+        Printer { times: 0 }
+    }
+}
+
+impl Actor for Printer {}
+
+struct Print(String);
+
+impl Message for Print {
+    type Result = ();
+}
+
+impl AsyncHandler<Print> for Printer {
+    type Responder<'a> = impl Future<Output = ()> + 'a;
+
+    fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
+        async move {
+            self.times += 1; // Look ma, no ActorFuture!
+            println!("Printing {}. Printed {} times so far.", print.0, self.times);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let addr = Printer::new().spawn();
+    loop {
+        addr.send_async(Print("hello".to_string()))
+            .await
+            .expect("Printer should not be dropped");
+    }
+}
+```
+
+## Okay, sounds great! How do I use it?
 Check out the [docs](https://docs.rs/xtra) and the [examples](https://github.com/Restioson/xtra/blob/master/examples)
 to get started! Enabling the `with-tokio-0_2` or `with-async_std-1` features are recommended in order to enable some 
 convenience methods (such as `Actor::spawn`). Which you enable will depend on which executor you want to use (check out
@@ -25,10 +82,3 @@ or message me on the [Rust discord](https://bit.ly/rust-community).
 - Actor notifications (sending messages to self) and creating an address from the actor's context
 - Scheduling of repeated-at-interval and time-delayed messages for actors
 
-## Limitations
-The main limitation of this crate is that it extensively uses unstable features. For example, to get rid of
-`ActorFuture`, [Generic Associated Types (GATs)](https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md)
-must be used. This is an incomplete and unstable feature, which [appears to be a way off from stabilisation](https://github.com/rust-lang/rust/issues/44265).
-It also uses [`impl Trait` Type Aliases](https://github.com/rust-lang/rfcs/pull/2515) to avoid `Box`ing the futures
-returned from the `AsyncHandler` trait (the library, however, is not alloc-free). This means that it requires nightly to
-use, and may be unstable.

--- a/examples/basic_async_std.rs
+++ b/examples/basic_async_std.rs
@@ -1,5 +1,4 @@
 use xtra::prelude::*;
-use xtra::{Disconnected, KeepRunning};
 
 struct Printer {
     times: usize,

--- a/examples/basic_async_std.rs
+++ b/examples/basic_async_std.rs
@@ -17,7 +17,7 @@ impl Message for Print {
     type Result = ();
 }
 
-impl Handler<Print> for Printer {
+impl SyncHandler<Print> for Printer {
     fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;
         println!("Printing {}. Printed {} times so far.", print.0, self.times);

--- a/examples/basic_async_std.rs
+++ b/examples/basic_async_std.rs
@@ -1,4 +1,5 @@
 use xtra::prelude::*;
+use xtra::{Disconnected, KeepRunning};
 
 struct Printer {
     times: usize,

--- a/examples/basic_async_std.rs
+++ b/examples/basic_async_std.rs
@@ -1,4 +1,4 @@
-use xtra::{Actor, Context, Handler, Message};
+use xtra::prelude::*;
 
 struct Printer {
     times: usize,

--- a/examples/basic_async_std_async.rs
+++ b/examples/basic_async_std_async.rs
@@ -1,7 +1,7 @@
 #![feature(type_alias_impl_trait, generic_associated_types)]
 
 use futures::Future;
-use xtra::{Actor, AsyncHandler, Context, Message};
+use xtra::prelude::*;
 
 struct Printer {
     times: usize,

--- a/examples/basic_async_std_async.rs
+++ b/examples/basic_async_std_async.rs
@@ -20,7 +20,7 @@ impl Message for Print {
     type Result = ();
 }
 
-impl AsyncHandler<Print> for Printer {
+impl Handler<Print> for Printer {
     type Responder<'a> = impl Future<Output = ()> + 'a;
 
     fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
@@ -35,7 +35,7 @@ impl AsyncHandler<Print> for Printer {
 async fn main() {
     let addr = Printer::new().spawn();
     loop {
-        addr.send_async(Print("hello".to_string()))
+        addr.send(Print("hello".to_string()))
             .await
             .expect("Printer should not be dropped");
     }

--- a/examples/basic_tokio.rs
+++ b/examples/basic_tokio.rs
@@ -17,7 +17,7 @@ impl Message for Print {
     type Result = ();
 }
 
-impl Handler<Print> for Printer {
+impl SyncHandler<Print> for Printer {
     fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;
         println!("Printing {}. Printed {} times so far.", print.0, self.times);

--- a/examples/basic_tokio.rs
+++ b/examples/basic_tokio.rs
@@ -1,4 +1,4 @@
-use xtra::{Actor, Context, Handler, Message};
+use xtra::prelude::*;
 
 struct Printer {
     times: usize,

--- a/examples/basic_tokio_async.rs
+++ b/examples/basic_tokio_async.rs
@@ -1,7 +1,7 @@
 #![feature(type_alias_impl_trait, generic_associated_types)]
 
 use futures::Future;
-use xtra::{Actor, AsyncHandler, Context, Handler, Message};
+use xtra::prelude::*;
 
 struct Printer {
     times: usize,

--- a/examples/basic_tokio_async.rs
+++ b/examples/basic_tokio_async.rs
@@ -20,7 +20,7 @@ impl Message for Print {
     type Result = ();
 }
 
-impl AsyncHandler<Print> for Printer {
+impl Handler<Print> for Printer {
     type Responder<'a> = impl Future<Output = ()> + 'a;
 
     fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
@@ -35,7 +35,7 @@ impl AsyncHandler<Print> for Printer {
 async fn main() {
     let addr = Printer::new().spawn();
     loop {
-        addr.send_async(Print("hello".to_string()))
+        addr.send(Print("hello".to_string()))
             .await
             .expect("Printer should not be dropped");
     }

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -17,28 +17,34 @@ impl Message for Increment {
     type Result = ();
 }
 
+struct IncrementAsync;
+
+impl Message for IncrementAsync {
+    type Result = ();
+}
+
 struct GetCount;
 
 impl Message for GetCount {
     type Result = usize;
 }
 
-impl Handler<Increment> for Counter {
+impl SyncHandler<Increment> for Counter {
     fn handle(&mut self, _: Increment, _ctx: &mut Context<Self>) {
         self.count += 1;
     }
 }
 
-impl AsyncHandler<Increment> for Counter {
+impl Handler<IncrementAsync> for Counter {
     type Responder<'a> = impl Future<Output = ()> + 'a;
 
-    fn handle(&mut self, _: Increment, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
+    fn handle(&mut self, _: IncrementAsync, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
         self.count += 1;
         async {} // Slower if you put count in here and make it async move (compiler optimisations?)
     }
 }
 
-impl Handler<GetCount> for Counter {
+impl SyncHandler<GetCount> for Counter {
     fn handle(&mut self, _: GetCount, _ctx: &mut Context<Self>) -> usize {
         let count = self.count;
         self.count = 0;
@@ -58,7 +64,7 @@ impl Message for TimeSend {
     type Result = ();
 }
 
-impl Handler<TimeSend> for SendTimer {
+impl SyncHandler<TimeSend> for SendTimer {
     fn handle(&mut self, time: TimeSend, _ctx: &mut Context<Self>) {
         self.time += time.0.elapsed();
     }
@@ -70,7 +76,7 @@ impl Message for GetTime {
     type Result = Duration;
 }
 
-impl Handler<GetTime> for SendTimer {
+impl SyncHandler<GetTime> for SendTimer {
     fn handle(&mut self, _time: GetTime, _ctx: &mut Context<Self>) -> Duration {
         self.time
     }
@@ -86,7 +92,7 @@ impl Message for TimeReturn {
     type Result = Instant;
 }
 
-impl Handler<TimeReturn> for ReturnTimer {
+impl SyncHandler<TimeReturn> for ReturnTimer {
     fn handle(&mut self, _time: TimeReturn, _ctx: &mut Context<Self>) -> Instant {
         Instant::now()
     }
@@ -114,13 +120,13 @@ async fn main() {
     println!("do_send avg time of processing: {}ns", average_ns);
     assert_eq!(total_count, COUNT, "total_count should equal COUNT!");
 
-    /* Time do_send_async */
+    /* Time do_send async */
 
     let addr = Counter { count: 0 }.spawn();
 
     let start = Instant::now();
     for _ in 0..COUNT {
-        let _ = addr.do_send_async(Increment);
+        let _ = addr.do_send(IncrementAsync);
     }
 
     // awaiting on GetCount will make sure all previous messages are processed first BUT introduces
@@ -129,7 +135,7 @@ async fn main() {
 
     let duration = Instant::now() - start;
     let average_ns = duration.as_nanos() / total_count as u128; // <170ns on my machine
-    println!("do_send_async avg time of processing: {}ns", average_ns);
+    println!("do_send async avg time of processing: {}ns", average_ns);
     assert_eq!(total_count, COUNT, "total_count should equal COUNT!");
 
     /* Time send avg time of processing */

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -110,7 +110,7 @@ async fn main() {
     let total_count = addr.send(GetCount).await.unwrap();
 
     let duration = Instant::now() - start;
-    let average_ns = duration.as_nanos() / total_count as u128; // ~150ns on my machine
+    let average_ns = duration.as_nanos() / total_count as u128; // <150ns on my machine
     println!("do_send avg time of processing: {}ns", average_ns);
     assert_eq!(total_count, COUNT, "total_count should equal COUNT!");
 
@@ -128,7 +128,7 @@ async fn main() {
     let total_count = addr.send(GetCount).await.unwrap();
 
     let duration = Instant::now() - start;
-    let average_ns = duration.as_nanos() / total_count as u128; // ~170ns on my machine
+    let average_ns = duration.as_nanos() / total_count as u128; // <170ns on my machine
     println!("do_send_async avg time of processing: {}ns", average_ns);
     assert_eq!(total_count, COUNT, "total_count should equal COUNT!");
 
@@ -146,7 +146,7 @@ async fn main() {
     let total_count = addr.send(GetCount).await.unwrap();
 
     let duration = Instant::now() - start;
-    let average_ns = duration.as_nanos() / total_count as u128; // ~350ns on my machine
+    let average_ns = duration.as_nanos() / total_count as u128; // 350~300ns on my machine
     println!("send avg time of processing: {}ns", average_ns);
     assert_eq!(total_count, COUNT, "total_count should equal COUNT!");
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -4,9 +4,9 @@ use crate::{Actor, Handler, Message, MessageChannel, WeakMessageChannel};
 use futures::channel::mpsc::UnboundedSender;
 use futures::channel::oneshot::Receiver;
 use futures::task::{Context, Poll};
-use futures::{Future, FutureExt, Sink};
+use futures::{Future, Sink};
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, FutureExt};
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
 
@@ -121,15 +121,17 @@ impl<A: Actor + Send> Address<A> {
     }
 
     pub fn channel<M: Message>(&self) -> MessageChannel<M>
-        where A: Handler<M>
+    where
+        A: Handler<M>,
     {
         MessageChannel {
-            address: Box::new(self.clone())
+            address: Box::new(self.clone()),
         }
     }
 
     pub fn into_channel<M: Message>(self) -> MessageChannel<M>
-        where A: Handler<M>
+    where
+        A: Handler<M>,
     {
         self.channel()
     }
@@ -238,15 +240,17 @@ pub struct WeakAddress<A: Actor> {
 
 impl<A: Actor + Send> WeakAddress<A> {
     pub fn channel<M: Message>(&self) -> WeakMessageChannel<M>
-        where A: Handler<M>
+    where
+        A: Handler<M>,
     {
         WeakMessageChannel {
-            address: Box::new(self.clone())
+            address: Box::new(self.clone()),
         }
     }
 
     pub fn into_channel<M: Message>(self) -> WeakMessageChannel<M>
-        where A: Handler<M>
+    where
+        A: Handler<M>,
     {
         self.channel()
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -88,6 +88,8 @@ impl<A: Actor> Address<A> {
 }
 
 impl<A: Actor> AddressExt<A> for Address<A> {
+    // To read more about what an envelope is and why we use them, look under `envelope.rs`
+
     fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
@@ -227,6 +229,8 @@ impl<A: Actor> Clone for WeakAddress<A> {
     }
 }
 
-/// The actor is no longer running and disconnected
+/// The actor is no longer running and disconnected from the sending address. For why this could
+/// occur, see the [`Actor::stopping`](trait.Actor.html#method.stopping) and
+/// [`Actor::stopped`](trait.Actor.html#method.stopped) methods.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Disconnected;

--- a/src/address.rs
+++ b/src/address.rs
@@ -179,7 +179,6 @@ impl<A: Actor> Drop for Address<A> {
         // should notify the ActorManager that there are potentially no more strong Addresses and the
         // actor should be stopped.
         if Arc::strong_count(&self.ref_counter) == 3 {
-            println!("sending last addr");
             let _ = self.sender.unbounded_send(ManagerMessage::LastAddress);
         }
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,88 +1,227 @@
 use crate::envelope::{
-    AsyncNonReturningEnvelope, AsyncReturningEnvelope, Envelope, SyncNonReturningEnvelope,
+    AsyncNonReturningEnvelope, AsyncReturningEnvelope, SyncNonReturningEnvelope,
     SyncReturningEnvelope,
 };
+use crate::manager::ManagerMessage;
 use crate::{Actor, AsyncHandler, Handler, Message};
 use futures::channel::mpsc::UnboundedSender;
-use futures::future::Either;
-use futures::{Future, TryFutureExt};
+use futures::channel::oneshot::Receiver;
+use futures::task::Poll;
+use futures::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Weak};
 
-/// An `Address` is a reference to an actor through which [`Message`s](trait.Message.html) can be
-/// sent. It can be cloned, and when all `Address`es are dropped, the actor will be stopped. It is
-/// created by calling the [`Actor::start`](trait.Actor.html#method.start) or
-/// [`Actor::spawn`](trait.Actor.html#method.start) methods.
-#[derive(Clone)]
-pub struct Address<A: Actor> {
-    pub(crate) sender: UnboundedSender<Box<dyn Envelope<Actor = A>>>,
+pub struct MessageResponseFuture<M: Message>(Receiver<M::Result>);
+
+impl<M: Message> Future for MessageResponseFuture<M> {
+    type Output = Result<M::Result, Disconnected>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut futures::task::Context) -> Poll<Self::Output> {
+        let rx = Pin::new(&mut self.get_mut().0);
+        rx.poll(ctx).map(|res| res.map_err(|_| Disconnected))
+    }
 }
 
-impl<A: Actor> Address<A> {
+/// General trait for any kind of address, be it strong or weak. This trait contains all functions
+/// of the address.
+#[doc(spotlight)]
+pub trait AddressExt<A: Actor> {
     /// Sends a [`Message`](trait.Message.html) that will be handled synchronously to the actor,
     /// and does not wait for a response. If this returns `Err(Disconnected)`, then the actor is stopped
     /// and not accepting messages. If this returns `Ok(())`, the will be delivered, but may
     /// not be handled in the event that the actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
     /// before it was handled.
-    pub fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
+    fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message,
+        A: Handler<M> + Send;
+
+    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
+    /// and does not wait for a response. If this returns `Err(Disconnected)`, then the actor is stopped
+    /// and not accepting messages. If this returns `Ok(())`, the will be delivered, but may
+    /// not be handled in the event that the actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
+    /// before it was handled.
+    fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message,
+        A: AsyncHandler<M> + Send;
+
+    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
+    /// and waits for a response. If this returns `Err(Disconnected)`, then the actor is stopped
+    /// and not accepting messages.
+    fn send<M>(&self, message: M) -> MessageResponseFuture<M>
+    where
+        M: Message,
+        A: Handler<M> + Send,
+        M::Result: Send;
+
+    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
+    /// and waits for a response. If this returns `Err(Disconnected)`, then the actor is stopped
+    /// and not accepting messages.
+    fn send_async<M>(&self, message: M) -> MessageResponseFuture<M>
+    where
+        M: Message,
+        A: AsyncHandler<M> + Send,
+        for<'a> A::Responder<'a>: Future<Output = M::Result> + Send;
+}
+
+/// An `Address` is a reference to an actor through which [`Message`s](trait.Message.html) can be
+/// sent. It can be cloned, and when all `Address`es are dropped, the actor will be stopped. It is
+/// created by calling the [`Actor::start`](trait.Actor.html#method.start) or
+/// [`Actor::spawn`](trait.Actor.html#method.start) methods.
+pub struct Address<A: Actor> {
+    pub(crate) sender: UnboundedSender<ManagerMessage<A>>,
+    pub(crate) ref_counter: Arc<()>,
+}
+
+impl<A: Actor> Address<A> {
+    /// Create a weak address to the actor. Unlike with the strong variety of address (this kind),
+    /// an actor will not be prevented from being dropped if only weak addresses exist.
+    pub fn weak(&self) -> WeakAddress<A> {
+        WeakAddress {
+            sender: self.sender.clone(),
+            ref_counter: Arc::downgrade(&self.ref_counter),
+        }
+    }
+}
+
+impl<A: Actor> AddressExt<A> for Address<A> {
+    fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
         A: Handler<M> + Send,
     {
         let envelope = SyncNonReturningEnvelope::new(message);
         self.sender
-            .unbounded_send(Box::new(envelope))
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
             .map_err(|_| Disconnected)
     }
 
-    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
-    /// and does not wait for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages. If this returns `Ok(())`, the will be delivered, but may
-    /// not be handled in the event that the actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
-    /// before it was handled.
-    pub fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
+    fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
         A: AsyncHandler<M> + Send,
     {
         let envelope = AsyncNonReturningEnvelope::new(message);
         self.sender
-            .unbounded_send(Box::new(envelope))
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
             .map_err(|_| Disconnected)
     }
 
-    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
-    /// and waits for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages.
-    pub fn send<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
+    fn send<M>(&self, message: M) -> MessageResponseFuture<M>
     where
         M: Message,
         A: Handler<M> + Send,
         M::Result: Send,
     {
         let (envelope, rx) = SyncReturningEnvelope::new(message);
-
         let _ = self
             .sender
-            .unbounded_send(Box::new(envelope));
-
-        rx.map_err(|_| Disconnected)
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
+        MessageResponseFuture(rx)
     }
 
-    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
-    /// and waits for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages.
-    pub fn send_async<M>(&self, message: M) -> impl Future<Output = Result<M::Result, Disconnected>>
+    fn send_async<M>(&self, message: M) -> MessageResponseFuture<M>
     where
         M: Message,
         A: AsyncHandler<M> + Send,
         for<'a> A::Responder<'a>: Future<Output = M::Result> + Send,
     {
         let (envelope, rx) = AsyncReturningEnvelope::new(message);
-
         let _ = self
             .sender
-            .unbounded_send(Box::new(envelope));
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
+        MessageResponseFuture(rx)
+    }
+}
 
-        rx.map_err(|_| Disconnected)
+// Required because #[derive] adds an A: Clone bound
+impl<A: Actor> Clone for Address<A> {
+    fn clone(&self) -> Self {
+        Address {
+            sender: self.sender.clone(),
+            ref_counter: self.ref_counter.clone(),
+        }
+    }
+}
+
+impl<A: Actor> Drop for Address<A> {
+    fn drop(&mut self) {
+        // Context holds one strong address (for `Context::address`), so if there are 2 strong
+        // addresses, this would be the 2nd-only one in existence. Therefore, we should notify the
+        // ActorManager that there are potentially no more strong Addresses and the actor should be
+        // stopped.
+        if Arc::strong_count(&self.ref_counter) == 2 {
+            let _ = self.sender.unbounded_send(ManagerMessage::LastAddress);
+        }
+    }
+}
+
+/// A `WeakAddress` is a reference to an actor through which [`Message`s](trait.Message.html) can be
+/// sent. It can be cloned. Unlike [`Address`](struct.Address.html), a `WeakAddress` will not inhibit
+/// the dropping of an actor. It is created by the [`Address::weak`](struct.Address.html) method.
+pub struct WeakAddress<A: Actor> {
+    pub(crate) sender: UnboundedSender<ManagerMessage<A>>,
+    ref_counter: Weak<()>,
+}
+
+impl<A: Actor> AddressExt<A> for WeakAddress<A> {
+    fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message,
+        A: Handler<M> + Send,
+    {
+        let envelope = SyncNonReturningEnvelope::new(message);
+        self.sender
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
+            .map_err(|_| Disconnected)
+    }
+
+    fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
+    where
+        M: Message,
+        A: AsyncHandler<M> + Send,
+    {
+        let envelope = AsyncNonReturningEnvelope::new(message);
+        self.sender
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
+            .map_err(|_| Disconnected)
+    }
+
+    fn send<M>(&self, message: M) -> MessageResponseFuture<M>
+    where
+        M: Message,
+        A: Handler<M> + Send,
+        M::Result: Send,
+    {
+        let (envelope, rx) = SyncReturningEnvelope::new(message);
+        let _ = self
+            .sender
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
+        MessageResponseFuture(rx)
+    }
+
+    fn send_async<M>(&self, message: M) -> MessageResponseFuture<M>
+    where
+        M: Message,
+        A: AsyncHandler<M> + Send,
+        for<'a> A::Responder<'a>: Future<Output = M::Result> + Send,
+    {
+        let (envelope, rx) = AsyncReturningEnvelope::new(message);
+        let _ = self
+            .sender
+            .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
+        MessageResponseFuture(rx)
+    }
+}
+
+// Required because #[derive] adds an A: Clone bound
+impl<A: Actor> Clone for WeakAddress<A> {
+    fn clone(&self) -> Self {
+        WeakAddress {
+            sender: self.sender.clone(),
+            ref_counter: self.ref_counter.clone(),
+        }
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,17 +1,14 @@
-use crate::envelope::{
-    AsyncNonReturningEnvelope, AsyncReturningEnvelope, SyncNonReturningEnvelope,
-    SyncReturningEnvelope,
-};
+use crate::envelope::{NonReturningEnvelope, ReturningEnvelope};
 use crate::manager::ManagerMessage;
-use crate::{Actor, AsyncHandler, Handler, Message};
+use crate::{Actor, Handler, Message};
 use futures::channel::mpsc::UnboundedSender;
 use futures::channel::oneshot::Receiver;
-use futures::task::Poll;
-use futures::Future;
-use std::pin::Pin;
-use std::sync::{Arc, Weak};
+use futures::task::{Context, Poll};
+use futures::{Future, FutureExt, Sink};
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
 use futures::{Stream, StreamExt};
+use std::pin::Pin;
+use std::sync::{Arc, Weak};
 
 /// The future returned by a method such as [`AddressExt::send`](trait.AddressExt.html#method.send).
 /// It resolves to `Result<M::Result, Disconnected>`.
@@ -29,7 +26,7 @@ impl<M: Message> Future for MessageResponseFuture<M> {
             MessageResponseFuture::Result(rx) => {
                 let rx = Pin::new(rx);
                 rx.poll(ctx).map(|res| res.map_err(|_| Disconnected))
-            },
+            }
         }
     }
 }
@@ -44,106 +41,54 @@ pub struct Disconnected;
 /// trait contains all functions of the address.
 #[doc(spotlight)]
 pub trait AddressExt<A: Actor> {
-    /// Sends a [`Message`](trait.Message.html) that will be handled synchronously to the actor,
-    /// and does not wait for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages. If this returns `Ok(())`, the will be delivered, but may
-    /// not be handled in the event that the actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
+    /// Returns whether the actor referred to by this address is running and accepting messages.
+    fn is_connected(&self) -> bool;
+
+    /// Sends a [`Message`](trait.Message.html) to the actor, and does not wait for a response.
+    /// If this returns `Err(Disconnected)`, then the actor is stopped and not accepting messages.
+    /// If this returns `Ok(())`, the will be delivered, but may not be handled in the event that the
+    /// actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
     /// before it was handled.
     fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
         A: Handler<M> + Send;
 
-    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
-    /// and does not wait for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages. If this returns `Ok(())`, the will be delivered, but may
-    /// not be handled in the event that the actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
-    /// before it was handled.
-    fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send;
-
-    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
-    /// and waits for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages.
+    /// Sends a [`Message`](trait.Message.html) to the actor, and waits for a response. If this
+    /// returns `Err(Disconnected)`, then the actor is stopped and not accepting messages.
     fn send<M>(&self, message: M) -> MessageResponseFuture<M>
     where
         M: Message,
         A: Handler<M> + Send,
         M::Result: Send;
 
-    /// Sends a [`Message`](trait.Message.html) that will be handled asynchronously to the actor,
-    /// and waits for a response. If this returns `Err(Disconnected)`, then the actor is stopped
-    /// and not accepting messages.
-    fn send_async<M>(&self, message: M) -> MessageResponseFuture<M>
+    /// Attaches a stream to this actor such that all messages produced by it are forwarded to the
+    /// actor. This could, for instance, be used to forward messages from a socket to the actor
+    /// (after the messages have been appropriately `map`ped). This is a convenience method over
+    /// explicitly forwarding a stream to this address, spawning that future onto the executor,
+    /// and mapping the error away (because disconnects are expected and will simply mean that the
+    /// stream is no longer being forwarded).
+    ///
+    /// **Note:** if this stream's continuation should prevent the actor from being dropped, this
+    /// method should be called on [`Address`](struct.Address.html). Otherwise, it should be called
+    /// on [`WeakAddress`](struct.WeakAddress.html).
+    #[doc(cfg(feature = "with-tokio-0_2"))]
+    #[doc(cfg(feature = "with-async_std-1"))]
+    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    fn attach_stream<S, M>(self, stream: S)
     where
         M: Message,
-        A: AsyncHandler<M> + Send,
-        for<'a> A::Responder<'a>: Future<Output = M::Result> + Send;
-
-    /// Attaches a stream to this actor such that all messages produced by it are forwarded to the
-    /// actor and handled synchronously. This could, for instance, be used to forward messages from a
-    /// socket to the actor (after the messages have been appropriately `map`ped). This is a
-    /// convenience method over a manual async stream forwarding loop.
-    #[doc(cfg(feature = "with-tokio-0_2"))]
-    #[doc(cfg(feature = "with-async_std-1"))]
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
-    fn attach_stream<S, M>(self, mut stream: S)
-        where M: Message,
-              A: Handler<M> + Send,
-              S: Stream<Item = M> + Send + Unpin + 'static,
-              Self: Sized + Send + 'static,
+        A: Handler<M> + Send,
+        S: Stream<Item = M> + Send + Unpin + 'static,
+        Self: Sized + Send + Sink<M, Error = Disconnected> + 'static,
     {
-        #[cfg(feature = "with-tokio-0_2")]
-        tokio::spawn(async move {
-            while let Some(msg) = stream.next().await {
-                if let Err(_) = self.do_send(msg) {
-                    break;
-                }
-            }
-        });
+        let fut = stream.map(|i| Ok(i)).forward(self).map(|_| ());
 
         #[cfg(feature = "with-async_std-1")]
-        async_std::task::spawn(async move {
-            while let Some(msg) = stream.next().await {
-                if let Err(_) = self.do_send(msg) {
-                    break;
-                }
-            }
-        });
-    }
+        async_std::task::spawn(fut);
 
-    /// Attaches a stream to this actor such that all messages produced by it are forwarded to the
-    /// actor and handled asynchronously. This could, for instance, be used to forward messages from a
-    /// socket to the actor (after the messages have been appropriately `map`ped). This is a
-    /// convenience method over a manual async stream forwarding loop.
-    #[doc(cfg(feature = "with-tokio-0_2"))]
-    #[doc(cfg(feature = "with-async_std-1"))]
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
-    fn attach_stream_async<S, M>(self, mut stream: S)
-        where M: Message,
-              A: AsyncHandler<M> + Send,
-              S: Stream<Item = M> + Send + Unpin + 'static,
-              Self: Sized + Send + 'static,
-    {
         #[cfg(feature = "with-tokio-0_2")]
-        tokio::spawn(async move {
-            while let Some(msg) = stream.next().await {
-                if let Err(_) = self.do_send_async(msg) {
-                    break;
-                }
-            }
-        });
-
-        #[cfg(feature = "with-async_std-1")]
-        async_std::task::spawn(async move {
-            while let Some(msg) = stream.next().await {
-                if let Err(_) = self.do_send_async(msg) {
-                    break;
-                }
-            }
-        });
+        tokio::spawn(fut);
     }
 }
 
@@ -161,7 +106,7 @@ pub struct Address<A: Actor> {
 impl<A: Actor> Address<A> {
     /// Create a weak address to the actor. Unlike with the strong variety of address (this kind),
     /// an actor will not be prevented from being dropped if only weak addresses exist.
-    pub fn weak(&self) -> WeakAddress<A> {
+    pub fn downgrade(&self) -> WeakAddress<A> {
         WeakAddress {
             sender: self.sender.clone(),
             ref_counter: Arc::downgrade(&self.ref_counter),
@@ -171,31 +116,23 @@ impl<A: Actor> Address<A> {
     /// Converts this address into a weak address to the actor. Unlike with the strong variety of
     /// address (this kind), an actor will not be prevented from being dropped if only weak addresses
     /// exist.
-    pub fn into_weak(self) -> WeakAddress<A> {
-        self.weak()
+    pub fn into_downgraded(self) -> WeakAddress<A> {
+        self.downgrade()
     }
 }
 
 impl<A: Actor> AddressExt<A> for Address<A> {
-    // To read more about what an envelope is and why we use them, look under `envelope.rs`
+    fn is_connected(&self) -> bool {
+        !self.sender.is_closed()
+    }
 
     fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
         A: Handler<M> + Send,
     {
-        let envelope = SyncNonReturningEnvelope::new(message);
-        self.sender
-            .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
-            .map_err(|_| Disconnected)
-    }
-
-    fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send,
-    {
-        let envelope = AsyncNonReturningEnvelope::new(message);
+        // To read more about what an envelope is and why we use them, look under `envelope.rs`
+        let envelope = NonReturningEnvelope::<A, M>::new(message);
         self.sender
             .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
             .map_err(|_| Disconnected)
@@ -207,24 +144,51 @@ impl<A: Actor> AddressExt<A> for Address<A> {
         A: Handler<M> + Send,
         M::Result: Send,
     {
-        let (envelope, rx) = SyncReturningEnvelope::new(message);
+        let (envelope, rx) = ReturningEnvelope::<A, M>::new(message);
         let _ = self
             .sender
             .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
         MessageResponseFuture::Result(rx)
     }
+}
 
-    fn send_async<M>(&self, message: M) -> MessageResponseFuture<M>
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send,
-        for<'a> A::Responder<'a>: Future<Output = M::Result> + Send,
-    {
-        let (envelope, rx) = AsyncReturningEnvelope::new(message);
-        let _ = self
-            .sender
-            .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
-        MessageResponseFuture::Result(rx)
+impl<M, A> Sink<M> for Address<A>
+where
+    M: Message,
+    A: Actor + Handler<M> + Send,
+{
+    type Error = Disconnected;
+
+    fn poll_ready(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.is_connected() {
+            self.sender.poll_ready(ctx).map_err(|_| Disconnected)
+        } else {
+            Poll::Ready(Err(Disconnected))
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, message: M) -> Result<(), Self::Error> {
+        if self.is_connected() {
+            let envelope = NonReturningEnvelope::<A, M>::new(message);
+            let msg = ManagerMessage::Message(Box::new(envelope));
+            Pin::new(&mut self.get_mut().sender)
+                .start_send(msg)
+                .map_err(|_| Disconnected)
+        } else {
+            Err(Disconnected)
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().sender)
+            .poll_flush(ctx)
+            .map_err(|_| Disconnected)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().sender)
+            .poll_close(ctx)
+            .map_err(|_| Disconnected)
     }
 }
 
@@ -259,31 +223,21 @@ pub struct WeakAddress<A: Actor> {
 }
 
 impl<A: Actor> AddressExt<A> for WeakAddress<A> {
+    fn is_connected(&self) -> bool {
+        // Check that there are external strong addresses. If there are none, the actor is
+        // disconnected and our message would interrupt its dropping. strong_count() == 2 because
+        // Context and manager both hold a strong arc to the refcount
+        self.ref_counter.strong_count() > 2 && !self.sender.is_closed()
+    }
+
     fn do_send<M>(&self, message: M) -> Result<(), Disconnected>
     where
         M: Message,
         A: Handler<M> + Send,
     {
-        // Check that there are external strong addresses. If there are none, the actor is
-        // disconnected and our message would interrupt its dropping. strong_count() == 2 because
-        // Context and manager both hold a strong arc to the refcount
-        if self.ref_counter.strong_count() > 2 {
-            let envelope = SyncNonReturningEnvelope::new(message);
-            self.sender
-                .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
-                .map_err(|_| Disconnected)
-        } else {
-            Err(Disconnected)
-        }
-    }
-
-    fn do_send_async<M>(&self, message: M) -> Result<(), Disconnected>
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send,
-    {
-        if self.ref_counter.strong_count() > 2 {
-            let envelope = AsyncNonReturningEnvelope::new(message);
+        if self.is_connected() {
+            // To read more about what an envelope is and why we use them, look under `envelope.rs`
+            let envelope = NonReturningEnvelope::<A, M>::new(message);
             self.sender
                 .unbounded_send(ManagerMessage::Message(Box::new(envelope)))
                 .map_err(|_| Disconnected)
@@ -298,8 +252,8 @@ impl<A: Actor> AddressExt<A> for WeakAddress<A> {
         A: Handler<M> + Send,
         M::Result: Send,
     {
-        if self.ref_counter.strong_count() > 2 {
-            let (envelope, rx) = SyncReturningEnvelope::new(message);
+        if self.is_connected() {
+            let (envelope, rx) = ReturningEnvelope::<A, M>::new(message);
             let _ = self
                 .sender
                 .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
@@ -308,21 +262,52 @@ impl<A: Actor> AddressExt<A> for WeakAddress<A> {
             MessageResponseFuture::Disconnected
         }
     }
+}
 
-    fn send_async<M>(&self, message: M) -> MessageResponseFuture<M>
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send,
-        for<'a> A::Responder<'a>: Future<Output = M::Result> + Send,
-    {
-        if self.ref_counter.strong_count() > 2 {
-            let (envelope, rx) = AsyncReturningEnvelope::new(message);
-            let _ = self
-                .sender
-                .unbounded_send(ManagerMessage::Message(Box::new(envelope)));
-            MessageResponseFuture::Result(rx)
+impl<M, A> Sink<M> for WeakAddress<A>
+where
+    M: Message,
+    A: Actor + Handler<M> + Send,
+{
+    type Error = Disconnected;
+
+    fn poll_ready(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.is_connected() {
+            self.sender.poll_ready(ctx).map_err(|_| Disconnected)
         } else {
-            MessageResponseFuture::Disconnected
+            Poll::Ready(Err(Disconnected))
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, message: M) -> Result<(), Self::Error> {
+        if self.is_connected() {
+            let envelope = NonReturningEnvelope::<A, M>::new(message);
+            let msg = ManagerMessage::Message(Box::new(envelope));
+            Pin::new(&mut self.get_mut().sender)
+                .start_send(msg)
+                .map_err(|_| Disconnected)
+        } else {
+            Err(Disconnected)
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.is_connected() {
+            Pin::new(&mut self.get_mut().sender)
+                .poll_flush(ctx)
+                .map_err(|_| Disconnected)
+        } else {
+            Poll::Ready(Err(Disconnected))
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.is_connected() {
+            Pin::new(&mut self.get_mut().sender)
+                .poll_close(ctx)
+                .map_err(|_| Disconnected)
+        } else {
+            Poll::Ready(Err(Disconnected))
         }
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -11,6 +11,8 @@ use futures::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
 
+/// The future returned by a method such as [`AddressExt::send`](trait.AddressExt.html#method.send).
+/// It resolves to `Result<M::Result, Disconnected>`.
 pub struct MessageResponseFuture<M: Message>(Receiver<M::Result>);
 
 impl<M: Message> Future for MessageResponseFuture<M> {
@@ -22,8 +24,14 @@ impl<M: Message> Future for MessageResponseFuture<M> {
     }
 }
 
-/// General trait for any kind of address, be it strong or weak. This trait contains all functions
-/// of the address.
+/// The actor is no longer running and disconnected from the sending address. For why this could
+/// occur, see the [`Actor::stopping`](trait.Actor.html#method.stopping) and
+/// [`Actor::stopped`](trait.Actor.html#method.stopped) methods.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Disconnected;
+
+/// General trait for any kind of address to an actor that is `Send`, be it strong or weak. This
+/// trait contains all functions of the address.
 #[doc(spotlight)]
 pub trait AddressExt<A: Actor> {
     /// Sends a [`Message`](trait.Message.html) that will be handled synchronously to the actor,
@@ -228,9 +236,3 @@ impl<A: Actor> Clone for WeakAddress<A> {
         }
     }
 }
-
-/// The actor is no longer running and disconnected from the sending address. For why this could
-/// occur, see the [`Actor::stopping`](trait.Actor.html#method.stopping) and
-/// [`Actor::stopped`](trait.Actor.html#method.stopped) methods.
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct Disconnected;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
 use crate::envelope::{MessageEnvelope, NonReturningEnvelope};
 use crate::manager::ManagerMessage;
-use crate::{Actor, Address, Message, Handler};
+use crate::{Actor, Address, Handler, Message};
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
 use {crate::AddressExt, std::time::Duration};
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use crate::envelope::{AsyncNonReturningEnvelope, Envelope, SyncNonReturningEnvelope};
-use crate::{Actor, Address, AsyncHandler, Handler, Message, WeakAddress};
+use crate::{Actor, Address, AsyncHandler, Handler, Message};
 use crate::manager::ManagerMessage;
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
 use {std::time::Duration, crate::AddressExt};

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,6 @@ use crate::{Actor, Address};
 pub struct Context<A: Actor> {
     /// Whether the actor is running. It is changed by the `stop` method as a flag to the `ActorManager`
     /// to calling the `stopping` method on the actor
-    // TODO stopping
     pub(crate) running: bool,
     /// The address kept by the context to
     address: Address<A>,
@@ -19,10 +18,10 @@ impl<A: Actor> Context<A> {
         }
     }
 
-    /// Stop the actor as soon as it has finished processing current message. This will mean that it
-    /// will be dropped, and [`Actor::stopped`](trait.Actor.html#method.stopped) will be called.
-    /// Any subsequent attempts to send messages to this actor will return the
-    /// [`Disconnected`](struct.Disconnected.html) error.
+    /// Stop the actor as soon as it has finished processing current message. This will mean that the
+    /// [`Actor::stopping`](trait.Actor.html#method.stopping) method will be called.
+    /// If that returns [`KeepRunning::No`](enum.KeepRunning.html#variant.No), any subsequent attempts
+    /// to send messages to this actor will return the [`Disconnected`](struct.Disconnected.html) error.
     pub fn stop(&mut self) {
         self.running = false;
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::envelope::{Envelope, NonReturningEnvelope};
+use crate::envelope::{MessageEnvelope, NonReturningEnvelope};
 use crate::manager::ManagerMessage;
 use crate::{Actor, Address, Message, Handler};
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
@@ -13,7 +13,7 @@ pub struct Context<A: Actor> {
     /// The address kept by the context to allow for the `Context::address` method to work.
     address: Address<A>,
     /// Notifications that must be stored for immediate processing.
-    pub(crate) immediate_notifications: Vec<Box<dyn Envelope<Actor = A>>>,
+    pub(crate) immediate_notifications: Vec<Box<dyn MessageEnvelope<Actor = A>>>,
 }
 
 impl<A: Actor> Context<A> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,9 +4,9 @@ use crate::{Actor, Address};
 /// management loop. Currently, it can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)).
 pub struct Context<A: Actor> {
     /// Whether the actor is running. It is changed by the `stop` method as a flag to the `ActorManager`
-    /// to calling the `stopping` method on the actor
+    /// for it to call the `stopping` method on the actor
     pub(crate) running: bool,
-    /// The address kept by the context to
+    /// The address kept by the context to allow for the `Context::address` method to work.
     address: Address<A>,
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
 use crate::envelope::{Envelope, NonReturningEnvelope};
 use crate::manager::ManagerMessage;
-use crate::{Actor, Address, Message, SyncHandler};
+use crate::{Actor, Address, Message, Handler};
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
 use {crate::AddressExt, std::time::Duration};
 
@@ -49,7 +49,7 @@ impl<A: Actor> Context<A> {
     pub fn notify_immediately<M>(&mut self, msg: M)
     where
         M: Message,
-        A: SyncHandler<M> + Send,
+        A: Handler<M> + Send,
     {
         let envelope = Box::new(NonReturningEnvelope::<A, M>::new(msg));
         self.immediate_notifications.push(envelope);
@@ -60,7 +60,7 @@ impl<A: Actor> Context<A> {
     pub fn notify_later<M>(&mut self, msg: M)
     where
         M: Message,
-        A: SyncHandler<M> + Send,
+        A: Handler<M> + Send,
     {
         let envelope = NonReturningEnvelope::<A, M>::new(msg);
         let _ = self
@@ -79,7 +79,7 @@ impl<A: Actor> Context<A> {
     where
         F: Send + 'static + Fn() -> M,
         M: Message,
-        A: SyncHandler<M> + Send,
+        A: Handler<M> + Send,
     {
         let addr = self.address.downgrade();
 
@@ -115,7 +115,7 @@ impl<A: Actor> Context<A> {
     pub fn notify_after<M>(&mut self, duration: Duration, notification: M)
     where
         M: Message,
-        A: SyncHandler<M> + Send,
+        A: Handler<M> + Send,
     {
         let addr = self.address.downgrade();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,8 +27,12 @@ impl<A: Actor> Context<A> {
         self.running = false;
     }
 
-    /// Get an address to the current actor.
-    pub fn address(&self) -> Address<A> {
-        self.address.clone()
+    /// Get an address to the current actor if the actor is still running.
+    pub fn address(&self) -> Option<Address<A>> {
+        if self.running {
+            Some(self.address.clone())
+        } else {
+            None
+        }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,18 +1,21 @@
-use crate::Actor;
-use std::marker::PhantomData;
+use crate::{Actor, Address};
 
 /// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
 /// management loop. Currently, it can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)).
 pub struct Context<A: Actor> {
+    /// Whether the actor is running. It is changed by the `stop` method as a flag to the `ActorManager`
+    /// to calling the `stopping` method on the actor
+    // TODO stopping
     pub(crate) running: bool,
-    phantom: PhantomData<A>, // TODO(weak_address)
+    /// The address kept by the context to
+    address: Address<A>,
 }
 
 impl<A: Actor> Context<A> {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(address: Address<A>) -> Self {
         Context {
             running: true,
-            phantom: PhantomData,
+            address,
         }
     }
 
@@ -22,5 +25,10 @@ impl<A: Actor> Context<A> {
     /// [`Disconnected`](struct.Disconnected.html) error.
     pub fn stop(&mut self) {
         self.running = false;
+    }
+
+    /// Get an address to the current actor.
+    pub fn address(&self) -> Address<A> {
+        self.address.clone()
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,8 @@
-use crate::envelope::{AsyncNonReturningEnvelope, Envelope, SyncNonReturningEnvelope};
-use crate::{Actor, Address, AsyncHandler, Handler, Message};
+use crate::envelope::{Envelope, NonReturningEnvelope};
 use crate::manager::ManagerMessage;
+use crate::{Actor, Address, Message, SyncHandler};
 #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
-use {std::time::Duration, crate::AddressExt};
+use {crate::AddressExt, std::time::Duration};
 
 /// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
 /// management loop. Currently, it can be used to stop the actor ([`Context::stop`](struct.Context.html#method.stop)).
@@ -49,22 +49,9 @@ impl<A: Actor> Context<A> {
     pub fn notify_immediately<M>(&mut self, msg: M)
     where
         M: Message,
-        A: Handler<M> + Send,
+        A: SyncHandler<M> + Send,
     {
-        let envelope = Box::new(SyncNonReturningEnvelope::new(msg));
-        self.immediate_notifications.push(envelope);
-    }
-
-    /// Notify this actor with a message that is handled asynchronously before any other messages
-    /// from the general queue are processed (therefore, immediately). If multiple
-    /// `notify_immediately` messages are queued, they will still be processed in the order that they
-    /// are queued (i.e the immediate priority is only over other messages).
-    pub fn notify_immediately_async<M>(&mut self, msg: M)
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send,
-    {
-        let envelope = Box::new(AsyncNonReturningEnvelope::new(msg));
+        let envelope = Box::new(NonReturningEnvelope::<A, M>::new(msg));
         self.immediate_notifications.push(envelope);
     }
 
@@ -73,22 +60,12 @@ impl<A: Actor> Context<A> {
     pub fn notify_later<M>(&mut self, msg: M)
     where
         M: Message,
-        A: Handler<M> + Send,
+        A: SyncHandler<M> + Send,
     {
-        let envelope = SyncNonReturningEnvelope::new(msg);
-        let _ = self.address.sender
-            .unbounded_send(ManagerMessage::LateNotification(Box::new(envelope)));
-    }
-
-    /// Notify this actor with a message that is handled asynchronously after any other messages
-    /// from the general queue are processed.
-    pub fn notify_later_async<M>(&mut self, msg: M)
-    where
-        M: Message,
-        A: AsyncHandler<M> + Send,
-    {
-        let envelope = AsyncNonReturningEnvelope::new(msg);
-        let _ = self.address.sender
+        let envelope = NonReturningEnvelope::<A, M>::new(msg);
+        let _ = self
+            .address
+            .sender
             .unbounded_send(ManagerMessage::LateNotification(Box::new(envelope)));
     }
 
@@ -102,9 +79,9 @@ impl<A: Actor> Context<A> {
     where
         F: Send + 'static + Fn() -> M,
         M: Message,
-        A: Handler<M> + Send,
+        A: SyncHandler<M> + Send,
     {
-        let addr = self.address.weak();
+        let addr = self.address.downgrade();
 
         #[cfg(feature = "with-tokio-0_2")]
         tokio::spawn(async move {
@@ -131,55 +108,16 @@ impl<A: Actor> Context<A> {
         }
     }
 
-    /// Notify the actor with an asynchronously handled message every interval until it is stopped
-    /// (either directly with [`Context::stop`](struct.Context.html#method.stop), or for a lack of
-    /// strong [`Address`es](struct.Address.html)). This does not take priority over other messages.
-    #[doc(cfg(feature = "with-tokio-0_2"))]
-    #[doc(cfg(feature = "with-async_std-1"))]
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
-    pub fn notify_interval_async<F, M>(&mut self, duration: Duration, constructor: F)
-        where
-            F: Send + 'static + Fn() -> M,
-            M: Message,
-            A: AsyncHandler<M> + Send,
-    {
-        let addr = self.address.weak();
-
-        #[cfg(feature = "with-tokio-0_2")]
-        tokio::spawn(async move {
-            let mut timer = tokio::time::interval(duration);
-            loop {
-                timer.tick().await;
-                if let Err(_) = addr.do_send_async(constructor()) {
-                    break;
-                }
-            }
-        });
-
-        #[cfg(feature = "with-async_std-1")]
-        {
-            use async_std::prelude::FutureExt;
-            async_std::task::spawn(async move {
-                loop {
-                    futures::future::ready(()).delay(duration.clone()).await;
-                    if let Err(_) = addr.do_send_async(constructor()) {
-                        break;
-                    }
-                }
-            });
-        }
-    }
-
     /// Notify the actor with a synchronously handled message after a certain duration has elapsed.
     /// This does not take priority over other messages.
     #[doc(cfg(feature = "with-async_std-1"))]
     #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     pub fn notify_after<M>(&mut self, duration: Duration, notification: M)
-        where
-            M: Message,
-            A: Handler<M> + Send,
+    where
+        M: Message,
+        A: SyncHandler<M> + Send,
     {
-        let addr = self.address.weak();
+        let addr = self.address.downgrade();
 
         #[cfg(feature = "with-tokio-0_2")]
         tokio::spawn(async move {
@@ -193,33 +131,6 @@ impl<A: Actor> Context<A> {
             async_std::task::spawn(async move {
                 futures::future::ready(()).delay(duration.clone()).await;
                 let _ = addr.do_send(notification);
-            });
-        }
-    }
-
-    /// Notify the actor with an asynchronously handled message after a certain duration has elapsed.
-    /// This does not take priority over other messages.
-    #[doc(cfg(feature = "with-async_std-1"))]
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
-    pub fn notify_after_async<M>(&mut self, duration: Duration, notification: M)
-        where
-            M: Message,
-            A: AsyncHandler<M> + Send,
-    {
-        let addr = self.address.weak();
-
-        #[cfg(feature = "with-tokio-0_2")]
-        tokio::spawn(async move {
-            tokio::time::delay_for(duration).await;
-            let _ = addr.do_send_async(notification);
-        });
-
-        #[cfg(feature = "with-async_std-1")]
-        {
-            use async_std::prelude::FutureExt;
-            async_std::task::spawn(async move {
-                futures::future::ready(()).delay(duration.clone()).await;
-                let _ = addr.do_send_async(notification);
             });
         }
     }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,9 +1,11 @@
-use crate::{Actor, Context, Handler, Message, SyncHandler, Disconnected, Address, AddressExt, WeakAddress};
+use crate::address::MessageResponseFuture;
+use crate::{
+    Actor, Address, AddressExt, Context, Disconnected, Handler, Message, SyncHandler, WeakAddress,
+};
 use futures::channel::oneshot::{self, Receiver, Sender};
 use futures::{future, Future, FutureExt, Sink};
 use std::marker::PhantomData;
 use std::pin::Pin;
-use crate::address::MessageResponseFuture;
 
 /// The type of future returned by `Envelope::handle`
 type Fut<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
@@ -173,8 +175,9 @@ pub(crate) trait AddressEnvelope<M: Message>: Sink<M, Error = Disconnected> + Un
 }
 
 impl<A, M> AddressEnvelope<M> for Address<A>
-    where A: Handler<M> + Send,
-          M: Message
+where
+    A: Handler<M> + Send,
+    M: Message,
 {
     fn is_connected(&self) -> bool {
         AddressExt::is_connected(self)
@@ -194,8 +197,9 @@ impl<A, M> AddressEnvelope<M> for Address<A>
 }
 
 impl<A, M> AddressEnvelope<M> for WeakAddress<A>
-    where A: Handler<M> + Send,
-          M: Message
+where
+    A: Handler<M> + Send,
+    M: Message,
 {
     fn is_connected(&self) -> bool {
         AddressExt::is_connected(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@ pub trait Actor: 'static + Sized {
 
     /// Called when the actor calls the [`Context::stop`](struct.Context.html#method.stop). This method
     /// can prevent the actor from stopping by returning [`KeepRunning::Yes`](enum.KeepRunning.html#variant.Yes).
+    ///
+    /// **Note:** this method will *only* be called when `Context::stop` is called. Other, general
+    /// destructor behaviour should be encapsulated in the [`Actor::stopped`](trait.Actor.html#method.stopped)
+    /// method.
     #[allow(unused_variables)]
     fn stopping(&mut self, ctx: &mut Context<Self>) -> KeepRunning {
         KeepRunning::No

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,16 @@
     specialization,
     type_alias_impl_trait,
     doc_cfg,
-    doc_spotlight,
+    doc_spotlight
 )]
 
 mod message_channel;
-pub use message_channel::{MessageChannelExt, MessageChannel, WeakMessageChannel};
+pub use message_channel::{MessageChannel, MessageChannelExt, WeakMessageChannel};
 
 mod envelope;
 
 mod address;
-pub use address::{AddressExt, Address, WeakAddress, Disconnected};
+pub use address::{Address, AddressExt, Disconnected, WeakAddress};
 
 mod context;
 pub use context::Context;
@@ -23,7 +23,7 @@ pub use manager::ActorManager;
 
 pub mod prelude {
     pub use crate::address::{Address, AddressExt};
-    pub use crate::message_channel::{MessageChannelExt, MessageChannel};
+    pub use crate::message_channel::{MessageChannel, MessageChannelExt};
     pub use crate::{Actor, Context, Handler, Message, SyncHandler};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-#![feature(generic_associated_types, doc_cfg)]
+#![feature(generic_associated_types, doc_cfg, doc_spotlight)]
 
 mod envelope;
 
 mod address;
-pub use address::{Address, Disconnected};
+pub use address::{Address, AddressExt, WeakAddress, Disconnected};
 
 mod context;
 pub use context::Context;
@@ -11,7 +11,12 @@ pub use context::Context;
 mod manager;
 pub use manager::ActorManager;
 
-use std::future::Future;
+pub mod prelude {
+    pub use crate::address::{Address, AddressExt};
+    pub use crate::{Actor, Context, Handler, AsyncHandler, Message};
+}
+
+use futures::future::Future;
 
 /// A message that can be sent to an [`Actor`](trait.Actor.html) for processing. They are processed
 /// one at a time. Only actors implementing the corresponding [`Handler<M>`](trait.Handler.html)
@@ -53,11 +58,21 @@ pub trait AsyncHandler<M: Message>: Actor {
 /// This will result in any attempt to send messages to the actor in future failing.
 pub trait Actor: 'static + Sized {
     /// Called as soon as the actor has been started.
-    fn started(&mut self, _ctx: &mut Context<Self>) {}
+    #[allow(unused_variables)]
+    fn started(&mut self, ctx: &mut Context<Self>) {}
+
+    /// Called when the actor is in the process of stopping. This could be used for any cleanup
+    /// before the actor is dropped that requires access to the actor's context. This method can also
+    /// prevent the actor from being dropped by returning [`KeepRunning::Yes`](enum.KeepRunning.html#variant.Yes).
+    /// Be aware that if [`KeepRunning::Yes`](enum.KeepRunning.html#variant.Yes) is returned
+    #[allow(unused_variables)]
+    fn stopping(&mut self, reason: StopReason, ctx: &mut Context<Self>) -> KeepRunning {
+        KeepRunning::No
+    }
 
     /// Called when the actor is in the process of stopping. This should be used for any final
     /// cleanup before the actor is dropped.
-    fn stopped(&mut self, _ctx: &mut Context<Self>) {}
+    fn stopped(&mut self) {}
 
     /// Spawns the actor onto the global runtime executor (i.e, `tokio` or `async_std`'s executors).
     #[doc(cfg(feature = "with-tokio-0_2"))]
@@ -65,7 +80,7 @@ pub trait Actor: 'static + Sized {
     #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     fn spawn(self) -> Address<Self>
     where
-        Self: Sized + Send,
+        Self: Send,
     {
         ActorManager::spawn(self)
     }
@@ -73,10 +88,25 @@ pub trait Actor: 'static + Sized {
     /// Returns the actor's address and manager in a ready-to-start state. To spawn the actor, the
     /// [`ActorManager::manage`](struct.ActorManager.html#method.manage) method must be called and
     /// the future it returns spawned onto an executor.
-    fn start(self) -> (Address<Self>, ActorManager<Self>)
-    where
-        Self: Sized,
-    {
+    fn start(self) -> (Address<Self>, ActorManager<Self>) {
         ActorManager::start(self)
     }
+}
+
+/// Whether to keep the actor running after it has been put into a stopping state.
+pub enum KeepRunning {
+    Yes,
+    No,
+}
+
+/// The reason that the actor was stopped.
+pub enum StopReason {
+    /// There are no more strong addresses to the actor. Assuming that there are no weak addresses ([`WeakAddress`](struct.WeakAddress.html)),
+    /// this means that the actor may never receive any work to do, since there would be no way to
+    /// send it messages to process. If it is desirable that the actor handles messages indefinitely,
+    /// then strong addresses ([`Address`](struct.Address.html)) should be used.
+    NoMoreAddresses,
+
+    /// [`Context::stop`](struct.Context.html#stop) was called by the actor itself.
+    StopCalled,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(generic_associated_types, doc_cfg, doc_spotlight)]
+#![feature(generic_associated_types, weak_counts, doc_cfg, doc_spotlight)]
 
 mod envelope;
 
@@ -90,7 +90,7 @@ pub trait Actor: 'static + Sized {
     /// Returns the actor's address and manager in a ready-to-start state. To spawn the actor, the
     /// [`ActorManager::manage`](struct.ActorManager.html#method.manage) method must be called and
     /// the future it returns spawned onto an executor.
-    fn start(self) -> (Address<Self>, ActorManager<Self>) {
+    fn create(self) -> (Address<Self>, ActorManager<Self>) {
         ActorManager::start(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub trait AsyncHandler<M: Message>: Actor {
 }
 
 /// An actor which can handle [`Message`s](trait.Message.html) one at a time. Actors can only be
-/// communicated with by sending [`Message`s](trait.Message.html) through their [`Address`ess](struct.Address.html).
+/// communicated with by sending [`Message`s](trait.Message.html) through their [`Address`es](struct.Address.html).
 /// They can modify their private state, respond to messages, and spawn other actors. They can also
 /// stop themselves through their [`Context`](struct.Context.html) by calling [`Context::stop`](struct.Context.html#method.stop).
 /// This will result in any attempt to send messages to the actor in future failing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,18 @@
     generic_associated_types,
     weak_counts,
     specialization,
-    type_alias_impl_trait
+    type_alias_impl_trait,
+    doc_cfg,
+    doc_spotlight,
 )]
-#![feature(doc_cfg, doc_spotlight)]
+
+mod message_channel;
+pub use message_channel::{MessageChannelExt, MessageChannel, WeakMessageChannel};
 
 mod envelope;
 
 mod address;
-pub use address::{Address, AddressExt, Disconnected, WeakAddress};
+pub use address::{AddressExt, Address, WeakAddress, Disconnected};
 
 mod context;
 pub use context::Context;
@@ -19,6 +23,7 @@ pub use manager::ActorManager;
 
 pub mod prelude {
     pub use crate::address::{Address, AddressExt};
+    pub use crate::message_channel::{MessageChannelExt, MessageChannel};
     pub use crate::{Actor, Context, Handler, Message, SyncHandler};
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,7 +1,7 @@
 use crate::envelope::Envelope;
 use crate::{Actor, Address, Context, KeepRunning};
 use futures::channel::mpsc::{self, UnboundedReceiver};
-use futures::{StreamExt};
+use futures::StreamExt;
 use std::sync::Arc;
 
 /// A message that can be sent by an [`Address`](struct.Address.html) to the [`ActorManager`](struct.ActorManager.html)
@@ -153,7 +153,6 @@ impl<A: Actor> ActorManager<A> {
                 }
             }
         }
-
 
         // Handle any last late notifications that were sent after the last strong address was dropped
         // We can't .await, because that would mean that we are awaiting forever! So, instead, we do

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,9 +1,8 @@
 use crate::envelope::Envelope;
 use crate::{Actor, Address, Context, KeepRunning};
 use futures::channel::mpsc::{self, UnboundedReceiver};
-use futures::{StreamExt, TryStreamExt};
+use futures::{StreamExt};
 use std::sync::Arc;
-use futures::task::Poll;
 
 /// A message that can be sent by an [`Address`](struct.Address.html) to the [`ActorManager`](struct.ActorManager.html)
 pub(crate) enum ManagerMessage<A: Actor> {
@@ -145,7 +144,6 @@ impl<A: Actor> ActorManager<A> {
                 // strong address to the actor, so we need to check if that is still the case, if so
                 // stopping the actor
                 ManagerMessage::LastAddress => {
-                    println!("{}", Arc::strong_count(&self.ref_counter));
                     // strong_count() == 2 because Context and manager both hold a strong arc to
                     // the refcount
                     if Arc::strong_count(&self.ref_counter) == 2 {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,4 @@
-use crate::envelope::Envelope;
+use crate::envelope::MessageEnvelope;
 use crate::{Actor, Address, Context, KeepRunning};
 use futures::channel::mpsc::{self, UnboundedReceiver};
 use futures::StreamExt;
@@ -13,9 +13,9 @@ pub(crate) enum ManagerMessage<A: Actor> {
     LastAddress,
     /// A message being sent to the actor. To read about envelopes and why we use them, check out
     /// `envelope.rs`
-    Message(Box<dyn Envelope<Actor = A>>),
+    Message(Box<dyn MessageEnvelope<Actor = A>>),
     /// A notification queued with `Context::notify_later`
-    LateNotification(Box<dyn Envelope<Actor = A>>),
+    LateNotification(Box<dyn MessageEnvelope<Actor = A>>),
 }
 
 /// A manager for the actor which handles incoming messages and stores the context. Its managing

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,8 +1,9 @@
 use crate::envelope::Envelope;
 use crate::{Actor, Address, Context, KeepRunning};
 use futures::channel::mpsc::{self, UnboundedReceiver};
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use std::sync::Arc;
+use futures::task::Poll;
 
 /// A message that can be sent by an [`Address`](struct.Address.html) to the [`ActorManager`](struct.ActorManager.html)
 pub(crate) enum ManagerMessage<A: Actor> {
@@ -14,6 +15,8 @@ pub(crate) enum ManagerMessage<A: Actor> {
     /// A message being sent to the actor. To read about envelopes and why we use them, check out
     /// `envelope.rs`
     Message(Box<dyn Envelope<Actor = A>>),
+    /// A notification queued with `Context::notify_later`
+    LateNotification(Box<dyn Envelope<Actor = A>>),
 }
 
 /// A manager for the actor which handles incoming messages and stores the context. Its managing
@@ -75,20 +78,44 @@ impl<A: Actor> ActorManager<A> {
         (addr, mgr)
     }
 
-    /// Starts the manager loop. This will start the actor and allow it to respond to messages.
-    pub async fn manage(mut self) {
-        self.actor.started(&mut self.ctx);
-
-        // Idk why anyone would do this, but we have to check that they didn't do ctx.stop() in the
-        // started method, otherwise it would kinda be a bug
+    /// Check if the Context is still sent to running, returning whether to return from the manage
+    /// loop or not
+    fn check_runnning(&mut self) -> bool {
+        // Check if the context was stopped, and if so return, thereby dropping the
+        // manager and calling `stopped` on the actor
         if !self.ctx.running {
             let keep_running = self.actor.stopping(&mut self.ctx);
 
             if keep_running == KeepRunning::Yes {
                 self.ctx.running = true;
             } else {
-                return; // Ok then
+                return false;
             }
+        }
+
+        true
+    }
+
+    /// Handle all immediate notifications, returning whether to return from the manage loop or not
+    async fn handle_immediate_notifications(&mut self) -> bool {
+        while let Some(notification) = self.ctx.immediate_notifications.pop() {
+            notification.handle(&mut self.actor, &mut self.ctx).await;
+            if !self.check_runnning() {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Starts the manager loop. This will start the actor and allow it to respond to messages.
+    pub async fn manage(mut self) {
+        self.actor.started(&mut self.ctx);
+
+        // Idk why anyone would do this, but we have to check that they didn't do ctx.stop() in the
+        // started method, otherwise it would kinda be a bug
+        if !self.check_runnning() {
+            return;
         }
 
         // Listen for any messages for the ActorManager
@@ -97,28 +124,53 @@ impl<A: Actor> ActorManager<A> {
                 // A new message from an address has arrived, so handle it
                 ManagerMessage::Message(msg) => {
                     msg.handle(&mut self.actor, &mut self.ctx).await;
-
-                    // Check if the context was stopped, and if so return, thereby dropping the
-                    // manager and calling `stopped` on the actor
-                    if !self.ctx.running {
-                        let keep_running = self.actor.stopping(&mut self.ctx);
-
-                        if keep_running == KeepRunning::Yes {
-                            self.ctx.running = true;
-                        } else {
-                            return;
-                        }
+                    if !self.check_runnning() {
+                        return;
+                    }
+                    if !self.handle_immediate_notifications().await {
+                        return;
+                    }
+                }
+                // A late notification has arrived, so handle it
+                ManagerMessage::LateNotification(notification) => {
+                    notification.handle(&mut self.actor, &mut self.ctx).await;
+                    if !self.check_runnning() {
+                        return;
+                    }
+                    if !self.handle_immediate_notifications().await {
+                        return;
                     }
                 }
                 // An address in the process of being dropped has realised that it could be the last
                 // strong address to the actor, so we need to check if that is still the case, if so
                 // stopping the actor
                 ManagerMessage::LastAddress => {
+                    println!("{}", Arc::strong_count(&self.ref_counter));
                     // strong_count() == 2 because Context and manager both hold a strong arc to
                     // the refcount
                     if Arc::strong_count(&self.ref_counter) == 2 {
-                        return;
+                        self.ctx.stop();
+                        break;
                     }
+                }
+            }
+        }
+
+
+        // Handle any last late notifications that were sent after the last strong address was dropped
+        // We can't .await, because that would mean that we are awaiting forever! So, instead, we do
+        // `next_message` and check if the result is `Ok`. Because we know that any late notifications
+        // sent from the context must be fully send by now due to it being marked as stopped (so
+        // that no other addresses can be created and sending concurrently), we can make the inference
+        // that if `next_message` returns `Err`, there are no more late notifications to handle.
+        while let Ok(Some(msg)) = self.receiver.try_next() {
+            if let ManagerMessage::LateNotification(notification) = msg {
+                notification.handle(&mut self.actor, &mut self.ctx).await;
+                if !self.check_runnning() {
+                    return;
+                }
+                if !self.handle_immediate_notifications().await {
+                    return;
                 }
             }
         }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -2,18 +2,31 @@ use crate::envelope::Envelope;
 use crate::{Actor, Address, Context};
 use futures::channel::mpsc::{self, UnboundedReceiver};
 use futures::StreamExt;
+use std::sync::Arc;
+
+/// A message that can be sent by an [`Address`](struct.Address.html) to the [`ActorManager`](struct.ActorManager.html)
+pub(crate) enum ManagerMessage<A: Actor> {
+    /// The address sending this is being dropped and is the only other strong address in existence
+    /// other than the one held by the [`Context`](struct.Context.html). This notifies the
+    /// [`ActorManager`](struct.ActorManager.html) so that it can check if the actor should be
+    /// dropped
+    LastAddress,
+    /// A message being sent to the actor
+    Message(Box<dyn Envelope<Actor = A>>),
+}
 
 /// A manager for the actor which handles incoming messages and stores the context. Its managing
 /// loop can be started with [`ActorManager::manage`](struct.ActorManager.html#method.manage).
 pub struct ActorManager<A: Actor> {
-    receiver: UnboundedReceiver<Box<dyn Envelope<Actor = A>>>,
+    receiver: UnboundedReceiver<ManagerMessage<A>>,
     actor: A,
     ctx: Context<A>,
+    ref_counter: Arc<()>,
 }
 
 impl<A: Actor> Drop for ActorManager<A> {
     fn drop(&mut self) {
-        self.actor.stopped(&mut self.ctx);
+        self.actor.stopped();
     }
 }
 
@@ -36,13 +49,19 @@ impl<A: Actor> ActorManager<A> {
 
     pub(crate) fn start(actor: A) -> (Address<A>, ActorManager<A>) {
         let (sender, receiver) = mpsc::unbounded();
-        let ctx = Context::new();
+        let ref_counter = Arc::new(());
+        let addr = Address {
+            sender,
+            ref_counter: ref_counter.clone(),
+        };
+        let ctx = Context::new(addr.clone());
+
         let mgr = ActorManager {
             receiver,
             actor,
             ctx,
+            ref_counter,
         };
-        let addr = Address { sender };
 
         (addr, mgr)
     }
@@ -52,11 +71,26 @@ impl<A: Actor> ActorManager<A> {
         self.actor.started(&mut self.ctx);
 
         while let Some(msg) = self.receiver.next().await {
-            msg.handle(&mut self.actor, &mut self.ctx).await;
+            match msg {
+                // A new message from an address has arrived, so handle it
+                ManagerMessage::Message(msg) => {
+                    msg.handle(&mut self.actor, &mut self.ctx).await;
 
-            // Check if the context was stopped
-            if !self.ctx.running {
-                return;
+                    // Check if the context was stopped, and if so return, thereby dropping the
+                    // manager and calling `stopped` on the actor
+                    if !self.ctx.running {
+                        return;
+                    }
+                }
+                // An address in the process of being dropped has realised that it could be the last
+                // strong address to the actor, so we need to check if that is still the case, if so
+                // stopping the actor
+                ManagerMessage::LastAddress => {
+                    // strong_count() == 1 because Context holds one strong address too
+                    if Arc::strong_count(&self.ref_counter) == 1 {
+                        return;
+                    }
+                }
             }
         }
     }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -1,0 +1,175 @@
+use crate::{Message, Disconnected};
+use crate::address::MessageResponseFuture;
+use futures::{Stream, StreamExt, Sink, FutureExt};
+use crate::envelope::AddressEnvelope;
+use std::pin::Pin;
+use futures::task::{Context, Poll};
+
+/// General trait for any kind of channel of messages, be it strong or weak. This trait contains all
+/// functions of the channel.
+pub trait MessageChannelExt<M: Message> {
+    /// Returns whether the actor referred to by this address is running and accepting messages.
+    fn is_connected(&self) -> bool;
+
+    /// Sends a [`Message`](trait.Message.html) to the actor, and does not wait for a response.
+    /// If this returns `Err(Disconnected)`, then the actor is stopped and not accepting messages.
+    /// If this returns `Ok(())`, the will be delivered, but may not be handled in the event that the
+    /// actor stops itself (by calling [`Context::stop`](struct.Context.html#method.stop))
+    /// before it was handled.
+    fn do_send(&self, message: M) -> Result<(), Disconnected>;
+
+    /// Sends a [`Message`](trait.Message.html) to the actor, and waits for a response. If this
+    /// returns `Err(Disconnected)`, then the actor is stopped and not accepting messages.
+    fn send(&self, message: M) -> MessageResponseFuture<M>;
+
+    /// Attaches a stream to this channel such that all messages produced by it are forwarded to the
+    /// actor. This could, for instance, be used to forward messages from a socket to the actor
+    /// (after the messages have been appropriately `map`ped). This is a convenience method over
+    /// explicitly forwarding a stream to this address, spawning that future onto the executor,
+    /// and mapping the error away (because disconnects are expected and will simply mean that the
+    /// stream is no longer being forwarded).
+    ///
+    /// **Note:** if this stream's continuation should prevent the actor from being dropped, this
+    /// method should be called on [`MessageChannel`](struct.MessageChannel.html). Otherwise, it should be called
+    /// on [`WeakMessageChannel`](struct.WeakMessageChannel.html).
+    #[doc(cfg(feature = "with-tokio-0_2"))]
+    #[doc(cfg(feature = "with-async_std-1"))]
+    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    fn attach_stream<S>(self, stream: S)
+        where
+            S: Stream<Item = M> + Send + Unpin + 'static,
+            Self: Sized + Send + Sink<M, Error = Disconnected> + 'static;
+}
+
+/// A message channel is a channel through which you can send only one kind of message, but to
+/// any actor that can handle it. It is like [`Address`](struct.Address.html), but associated with
+/// the message type rather than the actor type. Any existing `MessageChannel`s will prevent the
+/// dropping of the actor. If this is undesirable, then the [`WeakMessageChannel`](struct.WeakMessageChannel.html)
+/// struct should be used instead. This struct is created by calling
+/// [`Address::channel`](struct.Address.html#method.channel),
+/// [`Address::into_channel`](struct.Address.html#method.into_channel), or the similar methods on
+/// [`WeakAddress`](struct.WeakAddress.html).
+pub struct MessageChannel<M: Message> {
+    pub(crate) address: Box<dyn AddressEnvelope<M>>,
+}
+
+impl<M: Message> MessageChannel<M> {
+    pub fn downgrade(&self) -> WeakMessageChannel<M> {
+        WeakMessageChannel {
+            address: self.address.downgrade()
+        }
+    }
+
+    pub fn into_downgraded(self) -> WeakMessageChannel<M> {
+        self.downgrade()
+    }
+}
+
+impl<M: Message> MessageChannelExt<M> for MessageChannel<M> {
+    fn is_connected(&self) -> bool {
+        self.address.is_connected()
+    }
+
+    fn do_send(&self, message: M) -> Result<(), Disconnected> {
+        self.address.do_send(message)
+    }
+
+    fn send(&self, message: M) -> MessageResponseFuture<M> {
+        self.address.send(message)
+    }
+
+    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    fn attach_stream<S>(self, stream: S)
+        where
+            S: Stream<Item=M> + Send + Unpin + 'static,
+            Self: Sized + Send + Sink<M, Error=Disconnected> + 'static
+    {
+        let fut = stream.map(|i| Ok(i)).forward(self).map(|_| ());
+
+        #[cfg(feature = "with-async_std-1")]
+        async_std::task::spawn(fut);
+
+        #[cfg(feature = "with-tokio-0_2")]
+        tokio::spawn(fut);
+    }
+}
+
+impl<M: Message> Sink<M> for MessageChannel<M> {
+    type Error = Disconnected;
+
+    fn poll_ready(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().address).poll_ready(ctx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, message: M) -> Result<(), Self::Error> {
+        Pin::new(&mut self.get_mut().address).start_send(message)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().address).poll_flush(ctx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().address).poll_close(ctx)
+    }
+}
+
+/// A message channel is a channel through which you can send only one kind of message, but to
+/// any actor that can handle it. It is like [`Address`](struct.Address.html), but associated with
+/// the message type rather than the actor type. Any existing `WeakMessageChannel`s will *not* prevent the
+/// dropping of the actor. If this is undesirable, then the [`MessageChannel`](struct.MessageChannel.html)
+/// struct should be used instead. This struct is created by calling the
+/// [`MessageChannel::downgrade`](struct.MessageChannel.html#method.downgrade) or
+/// [`MessageChannel::into_downgraded`](struct.MessageChannel.html#method.into_downgraded) methods.
+pub struct WeakMessageChannel<M: Message> {
+    pub(crate) address: Box<dyn AddressEnvelope<M>>,
+}
+
+impl<M: Message> MessageChannelExt<M> for WeakMessageChannel<M> {
+    fn is_connected(&self) -> bool {
+        self.address.is_connected()
+    }
+
+    fn do_send(&self, message: M) -> Result<(), Disconnected> {
+        self.address.do_send(message)
+    }
+
+    fn send(&self, message: M) -> MessageResponseFuture<M> {
+        self.address.send(message)
+    }
+
+    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    fn attach_stream<S>(self, stream: S)
+        where
+            S: Stream<Item=M> + Send + Unpin + 'static,
+            Self: Sized + Send + Sink<M, Error=Disconnected> + 'static
+    {
+        let fut = stream.map(|i| Ok(i)).forward(self).map(|_| ());
+
+        #[cfg(feature = "with-async_std-1")]
+        async_std::task::spawn(fut);
+
+        #[cfg(feature = "with-tokio-0_2")]
+        tokio::spawn(fut);
+    }
+}
+
+impl<M: Message> Sink<M> for WeakMessageChannel<M> {
+    type Error = Disconnected;
+
+    fn poll_ready(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().address).poll_ready(ctx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, message: M) -> Result<(), Self::Error> {
+        Pin::new(&mut self.get_mut().address).start_send(message)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().address).poll_flush(ctx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().address).poll_close(ctx)
+    }
+}


### PR DESCRIPTION
- Weak addresses that don't prevent the actor from being dropped
- `notify_interval` to notify every x duration
- `notify_after` to notify after x duration
- attach streams to addresses

Todo:
- [x] Check that weak address send.await works 