### PR TITLE
Compile on stable

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,9 +1,17 @@
 # Breaking Changes by Version
 
+## 0.3.0
+
+- The default API of the `Handler` trait has now changed to an `async_trait` so that xtra can compile on stable.
+    - *How to upgrade, alternative 1:* change the implementations by annotating the implementation with `#[async_trait]`,
+      removing `Responder` and making `handle` an `async fn` which directly returns the message's result.
+    - *How to upgrade, alternative 2:* if you want to avoid the extra box, you can disable the default `stable` feature
+      in your `Cargo.toml` to keep the old API.
+
 ## 0.2.0
 
 - Removal of the `with-runtime` feature
-    - *How to upgrade:* You probably weren't using this anyway, but rather use `with-tokio-*` or `with-async_std-*`
+    - *How to upgrade:* you probably weren't using this anyway, but rather use `with-tokio-*` or `with-async_std-*`
     instead.
 - `Address` methods were moved to `AddressExt` to accommodate new `Address` types
     - *How to upgrade:* add `use xtra::AddressExt` to wherever address methods are used (or, better yet, 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtra"
-version = "0.2.8"
+version = "0.3.0"
 description = "A tiny actor framework"
 authors = ["Restioson <restiosondev@gmail.com>"]
 edition = "2018"
@@ -8,14 +8,18 @@ license = "MPL-2.0"
 repository = "https://github.com/Restioson/xtra"
 documentation = "https://docs.rs/xtra"
 readme = "README.md"
-keywords = ["async", "actor", "futures", "tokio", "async-std"]
+keywords = ["async", "actor", "futures", "xtra", "async-await"]
+categories = ["asynchronous", "concurrency"]
 
 [dependencies]
 futures = { version = "^0.3" }
+async-trait = { version = "^0.1", optional = true }
 tokio = { version = "^0.2", features = ["rt-core", "time"], optional = true }
 async-std = { version = "^1", features = ["unstable"], optional = true }
 
 [features]
+default = ["stable"]
+stable = ["async-trait"]
 with-tokio-0_2 = ["tokio"]
 with-async_std-1 = ["async-std"]
 
@@ -25,21 +29,21 @@ path = "examples/basic_tokio.rs"
 required-features = ["with-tokio-0_2", "tokio/full"]
 
 [[example]]
-name = "basic_tokio_async"
-path = "examples/basic_tokio_async.rs"
-required-features = ["with-tokio-0_2", "tokio/full"]
-
-[[example]]
 name = "basic_async_std"
 path = "examples/basic_async_std.rs"
-required-features = ["with-async_std-1", "async-std/attributes"]
+required-features = ["with-async_std-1", "async-std/attributes", "stable"]
 
 [[example]]
-name = "basic_async_std_async"
-path = "examples/basic_async_std_async.rs"
-required-features = ["with-async_std-1", "async-std/attributes"]
+name = "async_handler"
+path = "examples/async_handler.rs"
+required-features = ["with-tokio-0_2", "tokio/full", "stable"]
+
+[[example]]
+name = "nightly"
+path = "examples/nightly.rs"
+required-features = ["with-tokio-0_2", "tokio/full"]
 
 [[example]]
 name = "crude_bench"
 path = "examples/crude_bench.rs"
-required-features = ["with-tokio-0_2", "tokio/full"]
+required-features = ["with-tokio-0_2", "tokio/full", "stable"]

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ For better ergonomics with xtra, try the [spaad](https://crates.io/crates/spaad)
 
 ## Features
 - Safe: there is no unsafe code in xtra.
-- Small and lightweight: it only depends on `futures` and `async_trait` by default.
+- Tiny: xtra is only ~1.1kloc.
+- Lightweight: it only depends on `futures` and `async_trait` by default.
 - Asynchronous and synchronous message handlers.
 - Simple asynchronous message handling interface which allows `async`/`await` syntax even when borrowing `self`.
 - Does not depend on its own runtime and can be run with any futures executor ([Tokio](https://tokio.rs/) and 
 [async-std](https://async.rs/) have the `Actor::spawn` convenience method implemented out of the box).
-- Quite fast (under Tokio, <170ns time from sending a message to it being processed for sending without waiting for a 
-result on my development machine with an AMD Ryzen 3 3200G)
+- Quite fast. Running on Tokio, <170ns time from sending a message to it being processed for sending without waiting for a 
+result on my development machine with an AMD Ryzen 3 3200G.
 - However, it is also relatively new and less mature than other options.
 
 ## Example
@@ -60,6 +61,8 @@ async fn main() {
 
 For a longer example, check out [Vertex](https://github.com/Restioson/vertex/tree/development), a chat application
 written with xtra nightly (on the server).
+
+Too verbose? Check out the [spaad](https://crates.io/crates/spaad) sister-crate!
 
 ## Okay, sounds great! How do I use it?
 Check out the [docs](https://docs.rs/xtra) and the [examples](https://github.com/Restioson/xtra/blob/master/examples)

--- a/examples/async_handler.rs
+++ b/examples/async_handler.rs
@@ -1,5 +1,3 @@
-#![feature(type_alias_impl_trait, generic_associated_types)]
-
 use futures::Future;
 use xtra::prelude::*;
 
@@ -20,10 +18,9 @@ impl Message for Print {
     type Result = ();
 }
 
+#[async_trait::async_trait]
 impl Handler<Print> for Printer {
-    type Responder<'a> = impl Future<Output = ()> + 'a;
-
-    fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
+    async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         async move {
             self.times += 1;
             println!("Printing {}. Printed {} times so far.", print.0, self.times);

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -1,6 +1,3 @@
-#![feature(generic_associated_types, type_alias_impl_trait)]
-#![feature(asm)]
-
 use futures::Future;
 use std::time::{Duration, Instant};
 use xtra::prelude::*;
@@ -35,12 +32,10 @@ impl SyncHandler<Increment> for Counter {
     }
 }
 
+#[async_trait::async_trait]
 impl Handler<IncrementAsync> for Counter {
-    type Responder<'a> = impl Future<Output = ()> + 'a;
-
-    fn handle(&mut self, _: IncrementAsync, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
+    async fn handle(&mut self, _: IncrementAsync, _ctx: &mut Context<Self>) {
         self.count += 1;
-        async {} // Slower if you put count in here and make it async move (compiler optimisations?)
     }
 }
 

--- a/examples/nightly.rs
+++ b/examples/nightly.rs
@@ -1,7 +1,7 @@
 #![feature(type_alias_impl_trait, generic_associated_types)]
 
-use futures::Future;
 use xtra::prelude::*;
+use futures::Future;
 
 struct Printer {
     times: usize,
@@ -22,7 +22,6 @@ impl Message for Print {
 
 impl Handler<Print> for Printer {
     type Responder<'a> = impl Future<Output = ()> + 'a;
-
     fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> Self::Responder<'_> {
         async move {
             self.times += 1;
@@ -31,7 +30,7 @@ impl Handler<Print> for Printer {
     }
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     let addr = Printer::new().spawn();
     loop {

--- a/src/context.rs
+++ b/src/context.rs
@@ -38,7 +38,7 @@ impl<A: Actor> Context<A> {
         if self.running {
             let strong = Address {
                 sender: self.address.sender.clone(),
-                ref_counter: self.address.ref_counter.upgrade().unwrap()
+                ref_counter: self.address.ref_counter.upgrade().unwrap(),
             };
 
             Some(strong)
@@ -77,8 +77,8 @@ impl<A: Actor> Context<A> {
     /// Notify the actor with a synchronously handled message every interval until it is stopped
     /// (either directly with [`Context::stop`](struct.Context.html#method.stop), or for a lack of
     /// strong [`Address`es](struct.Address.html)). This does not take priority over other messages.
-    #[doc(cfg(feature = "with-tokio-0_2"))]
-    #[doc(cfg(feature = "with-async_std-1"))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-tokio-0_2")))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-async_std-1")))]
     #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     pub fn notify_interval<F, M>(&mut self, duration: Duration, constructor: F)
     where
@@ -115,7 +115,7 @@ impl<A: Actor> Context<A> {
 
     /// Notify the actor with a synchronously handled message after a certain duration has elapsed.
     /// This does not take priority over other messages.
-    #[doc(cfg(feature = "with-async_std-1"))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-async_std-1")))]
     #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     pub fn notify_after<M>(&mut self, duration: Duration, notification: M)
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub trait SyncHandler<M: Message>: Actor {
 /// With the `stable` feature enabled, this is an [`async_trait`](https://github.com/dtolnay/async-trait/),
 /// so implementations should be annotated `#[async_trait]`.
 #[cfg_attr(feature = "stable", async_trait::async_trait)]
+#[cfg(feature = "stable")]
 pub trait Handler<M: Message>: Actor {
     /// Handle a given message, returning its result.
     ///
@@ -69,14 +70,18 @@ pub trait Handler<M: Message>: Actor {
     /// ```ignore
     /// async fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> M::Result
     /// ```
-    #[cfg(feature = "stable")]
     async fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> M::Result;
+}
 
+/// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
+/// asynchronously, and the logic to handle the message. If the message should be handled synchronously,
+/// then the [`SyncHandler`](trait.SyncHandler.html) trait should rather be implemented.
+#[cfg(not(feature = "stable"))]
+pub trait Handler<M: Message>: Actor {
     /// The responding future of the asynchronous actor. This should probably look like:
     /// ```ignore
     /// type Responder<'a>: Future<Output = M::Result> + Send
     /// ```
-    #[cfg(not(feature = "stable"))]
     type Responder<'a>: Future<Output = M::Result> + Send;
 
     /// Handle a given message, returning a future eventually resolving to its result. The signature
@@ -88,7 +93,6 @@ pub trait Handler<M: Message>: Actor {
     /// ```ignore
     /// fn handle<'a>(&'a mut self, message: M, ctx: &'a mut Context<Self>) -> Self::Responder<'a>
     /// ```
-    #[cfg(not(feature = "stable"))]
     fn handle<'a>(&'a mut self, message: M, ctx: &'a mut Context<Self>) -> Self::Responder<'a>;
 }
 

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -34,8 +34,8 @@ pub trait MessageChannelExt<M: Message> {
     /// **Note:** if this stream's continuation should prevent the actor from being dropped, this
     /// method should be called on [`MessageChannel`](struct.MessageChannel.html). Otherwise, it should be called
     /// on [`WeakMessageChannel`](struct.WeakMessageChannel.html).
-    #[doc(cfg(feature = "with-tokio-0_2"))]
-    #[doc(cfg(feature = "with-async_std-1"))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-tokio-0_2")))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-async_std-1")))]
     #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
     fn attach_stream<S>(self, stream: S)
     where


### PR DESCRIPTION
Boxing with async_trait allows this to compile on stable, and perf impacts are negligible (still bottlenecked by the channel impl). `stable` feature added as a **default feature** (breaking change).