### PR TITLE
wasm-bindgen runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,16 @@ futures = { version = "^0.3" }
 async-trait = { version = "^0.1", optional = true }
 tokio = { version = "^0.2", features = ["rt-core", "time"], optional = true }
 async-std = { version = "^1", features = ["unstable"], optional = true }
+wasm-bindgen = { version = "^0.2", optional = true }
+wasm-bindgen-futures = { version = "^0.4", optional = true }
+futures-timer = { version = "3.0.2", optional = true }
 
 [features]
 default = ["stable"]
 stable = ["async-trait"]
 with-tokio-0_2 = ["tokio"]
 with-async_std-1 = ["async-std"]
+with-wasm_bindgen-0_2 = ["wasm-bindgen", "wasm-bindgen-futures", "futures-timer/wasm-bindgen"]
 
 [[example]]
 name = "basic_tokio"
@@ -47,3 +51,8 @@ required-features = ["with-tokio-0_2", "tokio/full"]
 name = "crude_bench"
 path = "examples/crude_bench.rs"
 required-features = ["with-tokio-0_2", "tokio/full", "stable"]
+
+[workspace]
+members = [
+    "examples/basic_wasm_bindgen"
+]

--- a/examples/basic_wasm_bindgen/Cargo.toml
+++ b/examples/basic_wasm_bindgen/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "basic-wasm-bindgen"
+version = "0.1.0"
+authors = ["stoically <stoically@protonmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.63"
+wasm-bindgen-futures = "0.4.13"
+xtra = { path = "../..", features = ["with-wasm_bindgen-0_2"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.13"

--- a/examples/basic_wasm_bindgen/README.md
+++ b/examples/basic_wasm_bindgen/README.md
@@ -1,0 +1,3 @@
+# xtra wasm-bindgen example
+
+Run tests with `wasm-pack test --headless --firefox`

--- a/examples/basic_wasm_bindgen/src/lib.rs
+++ b/examples/basic_wasm_bindgen/src/lib.rs
@@ -1,0 +1,35 @@
+use xtra::prelude::*;
+use wasm_bindgen::{JsValue, prelude::*};
+
+struct Printer;
+
+impl Printer {
+    fn new() -> Self {
+        Printer {}
+    }
+}
+
+impl Actor for Printer {}
+
+struct Print(String);
+impl Message for Print {
+    type Result = String;
+}
+
+impl SyncHandler<Print> for Printer {
+    fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) -> String {
+        print.0
+    }
+}
+
+#[wasm_bindgen]
+pub async fn start() -> Result<(), JsValue> {
+    let addr = Printer::new().spawn();
+    let response = addr.send(Print("hello world".to_string()))
+            .await
+            .expect("Printer should not be dropped");
+
+    assert_eq!(response, "hello world");
+
+    Ok(())
+}

--- a/examples/basic_wasm_bindgen/tests/web.rs
+++ b/examples/basic_wasm_bindgen/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn pass() {
+    basic_wasm_bindgen::start().await;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,13 @@ pub trait Actor: 'static + Sized {
     /// Spawns the actor onto the global runtime executor (i.e, `tokio` or `async_std`'s executors).
     #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-tokio-0_2")))]
     #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-async_std-1")))]
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-wasm_bindgen-0_2")))]
+    #[cfg(any(
+        doc,
+        feature = "with-tokio-0_2",
+        feature = "with-async_std-1",
+        feature = "with-wasm_bindgen-0_2",
+    ))]
     fn spawn(self) -> Address<Self>
     where
         Self: Send,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -38,7 +38,11 @@ impl<A: Actor> Drop for ActorManager<A> {
 
 impl<A: Actor> ActorManager<A> {
     /// Spawn the manager future onto the tokio or async-std executor
-    #[cfg(any(feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    #[cfg(any(
+        feature = "with-tokio-0_2",
+        feature = "with-async_std-1",
+        feature = "with-wasm_bindgen-0_2"
+    ))]
     pub(crate) fn spawn(actor: A) -> Address<A>
     where
         A: Send,
@@ -50,6 +54,9 @@ impl<A: Actor> ActorManager<A> {
 
         #[cfg(feature = "with-async_std-1")]
         async_std::task::spawn(mgr.manage());
+
+        #[cfg(feature = "with-wasm_bindgen-0_2")]
+        wasm_bindgen_futures::spawn_local(mgr.manage());
 
         addr
     }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -3,7 +3,12 @@ use crate::envelope::AddressEnvelope;
 use crate::{Disconnected, Message};
 use futures::task::{Context, Poll};
 use futures::Sink;
-#[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+#[cfg(any(
+    doc,
+    feature = "with-tokio-0_2",
+    feature = "with-async_std-1",
+    feature = "with-wasm_bindgen-0_2",
+))]
 use futures::{FutureExt, Stream, StreamExt};
 use std::pin::Pin;
 
@@ -36,7 +41,13 @@ pub trait MessageChannelExt<M: Message> {
     /// on [`WeakMessageChannel`](struct.WeakMessageChannel.html).
     #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-tokio-0_2")))]
     #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-async_std-1")))]
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    #[cfg_attr(not(feature = "stable"), doc(cfg(feature = "with-wasm_bindgen-0_2")))]
+    #[cfg(any(
+        doc,
+        feature = "with-tokio-0_2",
+        feature = "with-async_std-1",
+        feature = "with-wasm_bindgen-0_2"
+    ))]
     fn attach_stream<S>(self, stream: S)
     where
         S: Stream<Item = M> + Send + Unpin + 'static,
@@ -85,7 +96,12 @@ impl<M: Message> MessageChannelExt<M> for MessageChannel<M> {
         self.address.send(message)
     }
 
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    #[cfg(any(
+        doc,
+        feature = "with-tokio-0_2",
+        feature = "with-async_std-1",
+        feature = "with-wasm_bindgen-0_2"
+    ))]
     fn attach_stream<S>(self, stream: S)
     where
         S: Stream<Item = M> + Send + Unpin + 'static,
@@ -98,6 +114,9 @@ impl<M: Message> MessageChannelExt<M> for MessageChannel<M> {
 
         #[cfg(feature = "with-tokio-0_2")]
         tokio::spawn(fut);
+
+        #[cfg(feature = "with-wasm_bindgen-0_2")]
+        wasm_bindgen_futures::spawn_local(fut);
     }
 }
 
@@ -147,7 +166,12 @@ impl<M: Message> MessageChannelExt<M> for WeakMessageChannel<M> {
         self.address.send(message)
     }
 
-    #[cfg(any(doc, feature = "with-tokio-0_2", feature = "with-async_std-1"))]
+    #[cfg(any(
+        doc,
+        feature = "with-tokio-0_2",
+        feature = "with-async_std-1",
+        feature = "with-wasm_bindgen-0_2"
+    ))]
     fn attach_stream<S>(self, stream: S)
     where
         S: Stream<Item = M> + Send + Unpin + 'static,
@@ -160,6 +184,9 @@ impl<M: Message> MessageChannelExt<M> for WeakMessageChannel<M> {
 
         #[cfg(feature = "with-tokio-0_2")]
         tokio::spawn(fut);
+
+        #[cfg(feature = "with-wasm_bindgen-0_2")]
+        wasm_bindgen_futures::spawn_local(fut);
     }
 }
 


### PR DESCRIPTION
Thanks for xtra! Exactly what I was looking for.

The README states that xtra is runtime agnostic, but I couldn't find an easy way to use it in WASM without the tokio or async-std runtime feature, hence I added the wasm-bindgen support. Hope this is useful.

To run the example `cargo install wasm-pack` is required.

What's missing in this PR are the methods depending on time, like `notify_later`, but I'd be fine to file that as follow-up if the wasm-bindgen feature generally is something you want to support.