### PR TITLE
`Context::handle_while` and `Context::yield_once` for interleaving messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ path = "examples/nightly.rs"
 required-features = ["with-tokio-0_2", "tokio/full"]
 
 [[example]]
+name = "interleaved_messages"
+path = "examples/interleaved_messages.rs"
+required-features = ["with-tokio-0_2", "tokio/full", "stable"]
+
+
+[[example]]
 name = "crude_bench"
 path = "examples/crude_bench.rs"
 required-features = ["with-tokio-0_2", "tokio/full", "stable"]

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -1,4 +1,3 @@
-use futures::Future;
 use std::time::{Duration, Instant};
 use xtra::prelude::*;
 

--- a/examples/interleaved_messages.rs
+++ b/examples/interleaved_messages.rs
@@ -20,7 +20,7 @@ impl Actor for ActorA {}
 impl Handler<Hello> for ActorA {
     async fn handle(&mut self, _: Hello, ctx: &mut Context<Self>) {
         println!("ActorA: Hello");
-        ctx.select(self, self.actor_b.send(Hello)).await.unwrap();
+        ctx.handle_while(self, self.actor_b.send(Hello)).await.unwrap();
     }
 }
 
@@ -32,7 +32,7 @@ impl Handler<Initialized> for ActorB {
     async fn handle(&mut self, m: Initialized, ctx: &mut Context<Self>) {
         println!("ActorB: Initialized");
         let actor_a = m.0;
-        ctx.select(self, actor_a.send(Hello)).await.unwrap();
+        ctx.handle_while(self, actor_a.send(Hello)).await.unwrap();
     }
 }
 

--- a/examples/interleaved_messages.rs
+++ b/examples/interleaved_messages.rs
@@ -1,0 +1,54 @@
+use async_trait::async_trait;
+use xtra::prelude::*;
+
+struct Initialized(Address<ActorA>);
+impl Message for Initialized {
+    type Result = ();
+}
+
+struct Hello;
+impl Message for Hello {
+    type Result = ();
+}
+
+struct ActorA {
+    actor_b: Address<ActorB>,
+}
+impl Actor for ActorA {}
+
+#[async_trait]
+impl Handler<Hello> for ActorA {
+    async fn handle(&mut self, _: Hello, ctx: &mut Context<Self>) {
+        println!("ActorA: Hello");
+        ctx.select(self, self.actor_b.send(Hello)).await.unwrap();
+    }
+}
+
+struct ActorB;
+impl Actor for ActorB {}
+
+#[async_trait]
+impl Handler<Initialized> for ActorB {
+    async fn handle(&mut self, m: Initialized, ctx: &mut Context<Self>) {
+        println!("ActorB: Initialized");
+        let actor_a = m.0;
+        ctx.select(self, actor_a.send(Hello)).await.unwrap();
+    }
+}
+
+#[async_trait]
+impl Handler<Hello> for ActorB {
+    async fn handle(&mut self, _: Hello, _: &mut Context<Self>) {
+        println!("ActorB: Hello");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let actor_b = ActorB {}.spawn();
+    let actor_a = ActorA {
+        actor_b: actor_b.clone(),
+    }
+        .spawn();
+    actor_b.send(Initialized(actor_a.clone())).await.unwrap();
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -135,7 +135,7 @@ impl<A: Actor> Context<A> {
         ContinueManageLoop::Yes
     }
 
-    /// Yields to the manager to handle one message
+    /// Yields to the manager to handle one message.
     pub async fn yield_once(&mut self, act: &mut A) {
         if let Some(keep_running) = self.handle_immediate_notification(act).await {
             if !keep_running {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
 use crate::envelope::{MessageEnvelope, NonReturningEnvelope};
-use crate::manager::{ManagerMessage, ContinueManageLoop};
-use crate::{Actor, Address, Handler, Message, WeakAddress, KeepRunning};
+use crate::manager::ManagerMessage;
+use crate::{Actor, Address, Handler, Message, WeakAddress};
 use futures::channel::mpsc::UnboundedReceiver;
 #[cfg(any(
     doc,
@@ -10,9 +10,6 @@ use futures::channel::mpsc::UnboundedReceiver;
     feature = "with-smol-0_1"
 ))]
 use {crate::AddressExt, std::time::Duration};
-use futures::future::{self, Future, Either};
-use std::sync::Arc;
-use futures::StreamExt;
 
 /// `Context` is used to signal things to the [`ActorManager`](struct.ActorManager.html)'s
 /// management loop or to get the actor's address from inside of a message handler.
@@ -25,23 +22,18 @@ pub struct Context<A: Actor> {
     /// Notifications that must be stored for immediate processing.
     pub(crate) immediate_notifications: Vec<Box<dyn MessageEnvelope<Actor = A>>>,
     pub(crate) receiver: UnboundedReceiver<ManagerMessage<A>>,
-    /// The reference counter of the actor. This tells us how many external strong addresses
-    /// (and weak addresses, but we don't care about those) exist to the actor.
-    ref_counter: Arc<()>,
 }
 
 impl<A: Actor> Context<A> {
     pub(crate) fn new(
         address: WeakAddress<A>,
         receiver: UnboundedReceiver<ManagerMessage<A>>,
-        ref_counter: Arc<()>,
     ) -> Self {
         Context {
             running: true,
             address,
-            immediate_notifications: Vec::new(),
+            immediate_notifications: Vec::with_capacity(1),
             receiver,
-            ref_counter,
         }
     }
 
@@ -64,89 +56,6 @@ impl<A: Actor> Context<A> {
             Some(strong)
         } else {
             None
-        }
-    }
-
-    /// Check if the Context is still set to running, returning whether to return from the manage
-    /// loop or not
-    pub(crate) fn check_running(&mut self, actor: &mut A) -> bool {
-        // Check if the context was stopped, and if so return, thereby dropping the
-        // manager and calling `stopped` on the actor
-        if !self.running {
-            let keep_running = actor.stopping(self);
-
-            if keep_running == KeepRunning::Yes {
-                self.running = true;
-            } else {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Handle all immediate notifications, returning whether to return from the manage loop or not
-    async fn handle_immediate_notifications(&mut self, actor: &mut A) -> bool {
-        while let Some(notification) = self.immediate_notifications.pop() {
-            notification.handle(actor, self).await;
-            if !self.check_running(actor) {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Handle a message, returning whether to exit from the manage loop or not
-    pub(crate) async fn handle_message(
-        &mut self,
-        msg: ManagerMessage<A>,
-        actor: &mut A,
-    ) -> ContinueManageLoop {
-        match msg {
-            // A new message from an address or a notification has arrived, so handle it
-            ManagerMessage::Message(msg) | ManagerMessage::LateNotification(msg) => {
-                msg.handle(actor, self).await;
-                if !self.check_running(actor) {
-                    return ContinueManageLoop::ExitImmediately;
-                }
-                if !self.handle_immediate_notifications(actor).await {
-                    return ContinueManageLoop::ExitImmediately;
-                }
-            }
-            // An address in the process of being dropped has realised that it could be the last
-            // strong address to the actor, so we need to check if that is still the case, if so
-            // stopping the actor
-            ManagerMessage::LastAddress => {
-                // strong_count() == 1 manager holds a strong arc to the refcount
-                if Arc::strong_count(&self.ref_counter) == 1 {
-                    self.stop();
-                    return ContinueManageLoop::ProcessNotifications;
-                }
-            }
-        }
-        ContinueManageLoop::Yes
-    }
-
-    /// TODO doc
-    pub async fn select<F, R>(&mut self, act: &mut A, mut fut: F) -> R
-        where F: Future<Output = R> + Unpin,
-    {
-        let mut next_msg = self.receiver.next();
-        loop {
-            match future::select(fut, next_msg).await {
-                Either::Left((res, _)) => break res,
-                Either::Right((manager_message, unfinished_fut)) => {
-                    match manager_message {
-                        Some(msg) => {
-                            self.handle_message(msg, act).await;
-                        },
-                        None => self.stop(),
-                    }
-                    next_msg = self.receiver.next();
-                    fut = unfinished_fut;
-                }
-            }
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use crate::envelope::{MessageEnvelope, NonReturningEnvelope};
 use crate::manager::ManagerMessage;
 use crate::{Actor, Address, Handler, Message, WeakAddress};
+use futures::channel::mpsc::UnboundedReceiver;
 #[cfg(any(
     doc,
     feature = "with-tokio-0_2",
@@ -20,14 +21,19 @@ pub struct Context<A: Actor> {
     address: WeakAddress<A>,
     /// Notifications that must be stored for immediate processing.
     pub(crate) immediate_notifications: Vec<Box<dyn MessageEnvelope<Actor = A>>>,
+    pub(crate) receiver: UnboundedReceiver<ManagerMessage<A>>,
 }
 
 impl<A: Actor> Context<A> {
-    pub(crate) fn new(address: WeakAddress<A>) -> Self {
+    pub(crate) fn new(
+        address: WeakAddress<A>,
+        receiver: UnboundedReceiver<ManagerMessage<A>>,
+    ) -> Self {
         Context {
             running: true,
             address,
             immediate_notifications: Vec::with_capacity(1),
+            receiver,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use message_channel::{MessageChannel, MessageChannelExt, WeakMessageChannel}
 mod envelope;
 
 mod address;
-pub use address::{Address, AddressExt, Disconnected, WeakAddress};
+pub use address::{Address, AddressExt, Disconnected, WeakAddress, MessageResponseFuture};
 
 mod context;
 pub use context::Context;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,6 +1,6 @@
 use crate::envelope::MessageEnvelope;
-use crate::{Actor, Address, Context, WeakAddress};
-use futures::channel::mpsc;
+use crate::{Actor, Address, Context, KeepRunning, WeakAddress};
+use futures::channel::mpsc::{self, UnboundedReceiver};
 use futures::StreamExt;
 use std::sync::Arc;
 
@@ -18,19 +18,16 @@ pub(crate) enum ManagerMessage<A: Actor> {
     LateNotification(Box<dyn MessageEnvelope<Actor = A>>),
 }
 
-/// If and how to continue the manage loop
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
-pub(crate) enum ContinueManageLoop {
-    Yes,
-    ExitImmediately,
-    ProcessNotifications,
-}
-
 /// A manager for the actor which handles incoming messages and stores the context. Its managing
 /// loop can be started with [`ActorManager::manage`](struct.ActorManager.html#method.manage).
 pub struct ActorManager<A: Actor> {
+    receiver: UnboundedReceiver<ManagerMessage<A>>,
     actor: A,
     ctx: Context<A>,
+    /// The reference counter of the actor. This tells us how many external strong addresses
+    /// (and weak addresses, but we don't care about those) exist to the actor. This is obtained
+    /// by doing `Arc::strong_count(ref_count) - 1` because this ref counter itself in the manager adds to the count too.
+    ref_counter: Arc<()>,
 }
 
 impl<A: Actor> Drop for ActorManager<A> {
@@ -82,11 +79,13 @@ impl<A: Actor> ActorManager<A> {
             sender: sender.clone(),
             ref_counter: Arc::downgrade(&ref_counter),
         };
-        let ctx = Context::new(addr, receiver, ref_counter.clone());
+        let ctx = Context::new(addr);
 
         let mgr = ActorManager {
+            receiver,
             actor,
             ctx,
+            ref_counter: ref_counter.clone(),
         };
 
         let addr = Address {
@@ -97,22 +96,79 @@ impl<A: Actor> ActorManager<A> {
         (addr, mgr)
     }
 
+    /// Check if the Context is still sent to running, returning whether to return from the manage
+    /// loop or not
+    fn check_running(&mut self) -> bool {
+        // Check if the context was stopped, and if so return, thereby dropping the
+        // manager and calling `stopped` on the actor
+        if !self.ctx.running {
+            let keep_running = self.actor.stopping(&mut self.ctx);
+
+            if keep_running == KeepRunning::Yes {
+                self.ctx.running = true;
+            } else {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Handle all immediate notifications, returning whether to return from the manage loop or not
+    async fn handle_immediate_notifications(&mut self) -> bool {
+        while let Some(notification) = self.ctx.immediate_notifications.pop() {
+            notification.handle(&mut self.actor, &mut self.ctx).await;
+            if !self.check_running() {
+                return false;
+            }
+        }
+
+        true
+    }
+
     /// Starts the manager loop. This will start the actor and allow it to respond to messages.
     pub async fn manage(mut self) {
         self.actor.started(&mut self.ctx);
 
         // Idk why anyone would do this, but we have to check that they didn't do ctx.stop() in the
         // started method, otherwise it would kinda be a bug
-        if !self.ctx.check_running(&mut self.actor) {
+        if !self.check_running() {
             return;
         }
 
         // Listen for any messages for the ActorManager
-        while let Some(msg) = self.ctx.receiver.next().await {
-            match self.ctx.handle_message(msg, &mut self.actor).await {
-                ContinueManageLoop::Yes => {},
-                ContinueManageLoop::ProcessNotifications => break,
-                ContinueManageLoop::ExitImmediately => return,
+        while let Some(msg) = self.receiver.next().await {
+            match msg {
+                // A new message from an address has arrived, so handle it
+                ManagerMessage::Message(msg) => {
+                    msg.handle(&mut self.actor, &mut self.ctx).await;
+                    if !self.check_running() {
+                        return;
+                    }
+                    if !self.handle_immediate_notifications().await {
+                        return;
+                    }
+                }
+                // A late notification has arrived, so handle it
+                ManagerMessage::LateNotification(notification) => {
+                    notification.handle(&mut self.actor, &mut self.ctx).await;
+                    if !self.check_running() {
+                        return;
+                    }
+                    if !self.handle_immediate_notifications().await {
+                        return;
+                    }
+                }
+                // An address in the process of being dropped has realised that it could be the last
+                // strong address to the actor, so we need to check if that is still the case, if so
+                // stopping the actor
+                ManagerMessage::LastAddress => {
+                    // strong_count() == 1 manager holds a strong arc to the refcount
+                    if Arc::strong_count(&self.ref_counter) == 1 {
+                        self.ctx.stop();
+                        break;
+                    }
+                }
             }
         }
 
@@ -122,10 +178,15 @@ impl<A: Actor> ActorManager<A> {
         // sent from the context must be fully send by now due to it being marked as stopped (so
         // that no other addresses can be created and sending concurrently), we can make the inference
         // that if `next_message` returns `Err`, there are no more late notifications to handle.
-        while let Ok(Some(msg)) = self.ctx.receiver.try_next() {
-            let res = self.ctx.handle_message(msg, &mut self.actor).await;
-            if res == ContinueManageLoop::ExitImmediately {
-                break;
+        while let Ok(Some(msg)) = self.receiver.try_next() {
+            if let ManagerMessage::LateNotification(notification) = msg {
+                notification.handle(&mut self.actor, &mut self.ctx).await;
+                if !self.check_running() {
+                    return;
+                }
+                if !self.handle_immediate_notifications().await {
+                    return;
+                }
             }
         }
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,6 +1,6 @@
 use crate::envelope::MessageEnvelope;
-use crate::{Actor, Address, Context, KeepRunning, WeakAddress};
-use futures::channel::mpsc::{self, UnboundedReceiver};
+use crate::{Actor, Address, Context, WeakAddress};
+use futures::channel::mpsc;
 use futures::StreamExt;
 use std::sync::Arc;
 
@@ -18,15 +18,19 @@ pub(crate) enum ManagerMessage<A: Actor> {
     LateNotification(Box<dyn MessageEnvelope<Actor = A>>),
 }
 
+/// If and how to continue the manage loop
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+pub(crate) enum ContinueManageLoop {
+    Yes,
+    ExitImmediately,
+    ProcessNotifications,
+}
+
 /// A manager for the actor which handles incoming messages and stores the context. Its managing
 /// loop can be started with [`ActorManager::manage`](struct.ActorManager.html#method.manage).
 pub struct ActorManager<A: Actor> {
     actor: A,
     ctx: Context<A>,
-    /// The reference counter of the actor. This tells us how many external strong addresses
-    /// (and weak addresses, but we don't care about those) exist to the actor. This is obtained
-    /// by doing `Arc::strong_count(ref_count) - 1` because this ref counter itself in the manager adds to the count too.
-    ref_counter: Arc<()>,
 }
 
 impl<A: Actor> Drop for ActorManager<A> {
@@ -78,12 +82,11 @@ impl<A: Actor> ActorManager<A> {
             sender: sender.clone(),
             ref_counter: Arc::downgrade(&ref_counter),
         };
-        let ctx = Context::new(addr, receiver);
+        let ctx = Context::new(addr, receiver, ref_counter.clone());
 
         let mgr = ActorManager {
             actor,
             ctx,
-            ref_counter: ref_counter.clone(),
         };
 
         let addr = Address {
@@ -94,79 +97,22 @@ impl<A: Actor> ActorManager<A> {
         (addr, mgr)
     }
 
-    /// Check if the Context is still sent to running, returning whether to return from the manage
-    /// loop or not
-    fn check_running(&mut self) -> bool {
-        // Check if the context was stopped, and if so return, thereby dropping the
-        // manager and calling `stopped` on the actor
-        if !self.ctx.running {
-            let keep_running = self.actor.stopping(&mut self.ctx);
-
-            if keep_running == KeepRunning::Yes {
-                self.ctx.running = true;
-            } else {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Handle all immediate notifications, returning whether to return from the manage loop or not
-    async fn handle_immediate_notifications(&mut self) -> bool {
-        while let Some(notification) = self.ctx.immediate_notifications.pop() {
-            notification.handle(&mut self.actor, &mut self.ctx).await;
-            if !self.check_running() {
-                return false;
-            }
-        }
-
-        true
-    }
-
     /// Starts the manager loop. This will start the actor and allow it to respond to messages.
     pub async fn manage(mut self) {
         self.actor.started(&mut self.ctx);
 
         // Idk why anyone would do this, but we have to check that they didn't do ctx.stop() in the
         // started method, otherwise it would kinda be a bug
-        if !self.check_running() {
+        if !self.ctx.check_running(&mut self.actor) {
             return;
         }
 
         // Listen for any messages for the ActorManager
         while let Some(msg) = self.ctx.receiver.next().await {
-            match msg {
-                // A new message from an address has arrived, so handle it
-                ManagerMessage::Message(msg) => {
-                    msg.handle(&mut self.actor, &mut self.ctx).await;
-                    if !self.check_running() {
-                        return;
-                    }
-                    if !self.handle_immediate_notifications().await {
-                        return;
-                    }
-                }
-                // A late notification has arrived, so handle it
-                ManagerMessage::LateNotification(notification) => {
-                    notification.handle(&mut self.actor, &mut self.ctx).await;
-                    if !self.check_running() {
-                        return;
-                    }
-                    if !self.handle_immediate_notifications().await {
-                        return;
-                    }
-                }
-                // An address in the process of being dropped has realised that it could be the last
-                // strong address to the actor, so we need to check if that is still the case, if so
-                // stopping the actor
-                ManagerMessage::LastAddress => {
-                    // strong_count() == 1 manager holds a strong arc to the refcount
-                    if Arc::strong_count(&self.ref_counter) == 1 {
-                        self.ctx.stop();
-                        break;
-                    }
-                }
+            match self.ctx.handle_message(msg, &mut self.actor).await {
+                ContinueManageLoop::Yes => {},
+                ContinueManageLoop::ProcessNotifications => break,
+                ContinueManageLoop::ExitImmediately => return,
             }
         }
 
@@ -177,14 +123,9 @@ impl<A: Actor> ActorManager<A> {
         // that no other addresses can be created and sending concurrently), we can make the inference
         // that if `next_message` returns `Err`, there are no more late notifications to handle.
         while let Ok(Some(msg)) = self.ctx.receiver.try_next() {
-            if let ManagerMessage::LateNotification(notification) = msg {
-                notification.handle(&mut self.actor, &mut self.ctx).await;
-                if !self.check_running() {
-                    return;
-                }
-                if !self.handle_immediate_notifications().await {
-                    return;
-                }
+            let res = self.ctx.handle_message(msg, &mut self.actor).await;
+            if res == ContinueManageLoop::ExitImmediately {
+                break;
             }
         }
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -21,7 +21,6 @@ pub(crate) enum ManagerMessage<A: Actor> {
 /// A manager for the actor which handles incoming messages and stores the context. Its managing
 /// loop can be started with [`ActorManager::manage`](struct.ActorManager.html#method.manage).
 pub struct ActorManager<A: Actor> {
-    receiver: UnboundedReceiver<ManagerMessage<A>>,
     actor: A,
     ctx: Context<A>,
     /// The reference counter of the actor. This tells us how many external strong addresses
@@ -79,10 +78,9 @@ impl<A: Actor> ActorManager<A> {
             sender: sender.clone(),
             ref_counter: Arc::downgrade(&ref_counter),
         };
-        let ctx = Context::new(addr);
+        let ctx = Context::new(addr, receiver);
 
         let mgr = ActorManager {
-            receiver,
             actor,
             ctx,
             ref_counter: ref_counter.clone(),
@@ -137,7 +135,7 @@ impl<A: Actor> ActorManager<A> {
         }
 
         // Listen for any messages for the ActorManager
-        while let Some(msg) = self.receiver.next().await {
+        while let Some(msg) = self.ctx.receiver.next().await {
             match msg {
                 // A new message from an address has arrived, so handle it
                 ManagerMessage::Message(msg) => {
@@ -178,7 +176,7 @@ impl<A: Actor> ActorManager<A> {
         // sent from the context must be fully send by now due to it being marked as stopped (so
         // that no other addresses can be created and sending concurrently), we can make the inference
         // that if `next_message` returns `Err`, there are no more late notifications to handle.
-        while let Ok(Some(msg)) = self.receiver.try_next() {
+        while let Ok(Some(msg)) = self.ctx.receiver.try_next() {
             if let ManagerMessage::LateNotification(notification) = msg {
                 notification.handle(&mut self.actor, &mut self.ctx).await;
                 if !self.check_running() {


### PR DESCRIPTION
This PR adds two methods:
- `Context::handle_while`, allowing the user to handle messages as they arrive while running a given future. This future must be `Unpin` and may not borrow from `self`. It is implemented as a `select` between the two futures, repeating the future waiting for the next message until the first future completes.
- `Context::yield_once`, allowing the user to yield control back to the manager and handle a single message.

This change required some internal refactoring, namely moving handling of messages to the context, but was otherwise very simple to implement and does not introduce much technical debt.

To do:
- [x] Documentation
- [x] Handle immediate notifications first

Potentially closes #13 