### PR TITLE
Quality of my life

### DIFF
--- a/examples/message_stealing.rs
+++ b/examples/message_stealing.rs
@@ -21,7 +21,7 @@ impl Printer {
 
 #[async_trait::async_trait]
 impl Actor for Printer {
-    async fn stopped(&mut self) {
+    async fn stopped(self) {
         println!("Actor {} stopped", self.id);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub trait Handler<M: Message>: Actor {
 ///         KeepRunning::StopAll
 ///     }
 ///
-///     async fn stopped(&mut self) {
+///     async fn stopped(self) {
 ///         println!("Finally stopping.");
 ///     }
 /// }
@@ -194,7 +194,7 @@ pub trait Actor: 'static + Send + Sized {
     /// [`WeakAddress`](address/type.WeakAddress.html). This should be used for any final cleanup before
     /// the actor is dropped.
     #[allow(unused_variables)]
-    async fn stopped(&mut self) {}
+    async fn stopped(self) {}
 
     /// Returns the actor's address and manager in a ready-to-start state, given the cap for the
     /// actor's mailbox. If `None` is passed, it will be of unbounded size. To spawn the actor,

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -65,7 +65,7 @@ impl<M: Message> Future for SendFuture<M> {
 ///
 /// #[async_trait::async_trait]
 /// impl Actor for Alice {
-///     async fn stopped(&mut self) {
+///     async fn stopped(self) {
 ///         println!("Oh no");
 ///     }
 /// }

--- a/src/refcount.rs
+++ b/src/refcount.rs
@@ -61,6 +61,9 @@ pub trait RefCounter: Clone + Unpin + Send + Sync + 'static {
 
     #[doc(hidden)]
     fn into_either(self) -> Either;
+
+    #[doc(hidden)]
+    fn as_ptr(&self) -> *const AtomicBool;
 }
 
 impl RefCounter for Strong {
@@ -78,6 +81,10 @@ impl RefCounter for Strong {
 
     fn into_either(self) -> Either {
         Either::Strong(self)
+    }
+
+    fn as_ptr(&self) -> *const AtomicBool {
+        Arc::as_ptr(&self.0)
     }
 }
 
@@ -102,6 +109,10 @@ impl RefCounter for Weak {
 
     fn into_either(self) -> Either {
         Either::Weak(self)
+    }
+
+    fn as_ptr(&self) -> *const AtomicBool {
+        ArcWeak::as_ptr(&self.0)
     }
 }
 
@@ -129,5 +140,12 @@ impl RefCounter for Either {
 
     fn into_either(self) -> Either {
         self
+    }
+
+    fn as_ptr(&self) -> *const AtomicBool {
+        match self {
+            Either::Strong(s) => s.as_ptr(),
+            Either::Weak(s) => s.as_ptr(),
+        }
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -61,7 +61,7 @@ impl Actor for DropTester {
         KeepRunning::StopAll
     }
 
-    async fn stopped(&mut self) {
+    async fn stopped(self) {
         self.0.fetch_add(1, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
* Take `Actor` by value in `stopped` lifecycle method (API breaking, but more permissive)
* Implement `PartialEq + Eq + PartialOrd + Ord + Hash` on `Address` by pointer identity
  (uses the `ref_counter`, because `flume::Sender` doesn't expose `Arc` or pointer)

---
### Original PR description:

real find and replace hours