### PR TITLE
Annotate SendFuture with #[must_use] attribute

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -24,6 +24,7 @@ use crate::{Actor, Handler, KeepRunning, Message};
 /// It resolves to `Result<M::Result, Disconnected>`.
 // This simply wraps the enum in order to hide the implementation details of the inner future
 // while still leaving outer future nameable.
+#[must_use]
 pub struct SendFuture<A: Actor, M: Message>(SendFutureInner<A, M>);
 
 enum SendFutureInner<A: Actor, M: Message> {


### PR DESCRIPTION
Prevents misuses of the API, e.g.

`address.send()` without calling `.await` on it.