### PR TITLE
Annotate DoSendFuture with #[must_use] attribute

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -71,6 +71,7 @@ impl<A: Actor, M: Message> Future for SendFuture<A, M> {
 
 /// The future returned from [`Address::do_send_async`](struct.Address.html#method.do_send_async).
 /// It resolves to `Result<(), Disconnected>`.
+#[must_use]
 pub struct DoSendFuture<A: Actor>(DoSendFutureInner<A>);
 
 enum DoSendFutureInner<A: Actor> {


### PR DESCRIPTION
Prevents misuses of the API, e.g.

`address.do_send_async()` without calling `.await` on it.

Sorry, I missed the second use-case - ideally I would have sent a single PR!