### PR TITLE
Remove `Actor` trait bounds from structs

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -116,7 +116,7 @@ impl Error for Disconnected {}
 /// should be used instead. An address is created by calling the
 /// [`Actor::create`](../trait.Actor.html#method.create) or
 /// [`Context::run`](../struct.Context.html#method.run) methods, or by cloning another `Address`.
-pub struct Address<A: Actor, Rc: RefCounter = Strong> {
+pub struct Address<A, Rc: RefCounter = Strong> {
     pub(crate) sender: Sender<AddressMessage<A>>,
     pub(crate) ref_counter: Rc,
 }
@@ -128,7 +128,7 @@ pub struct Address<A: Actor, Rc: RefCounter = Strong> {
 pub type WeakAddress<A> = Address<A, Weak>;
 
 /// Functions which apply only to strong addresses (the default kind).
-impl<A: Actor> Address<A, Strong> {
+impl<A> Address<A, Strong> {
     /// Create a weak address to the actor. Unlike with the strong variety of address (this kind),
     /// an actor will not be prevented from being dropped if only weak sinks, channels, and
     /// addresses exist.
@@ -141,7 +141,7 @@ impl<A: Actor> Address<A, Strong> {
 }
 
 /// Functions which apply only to addresses which can either be strong or weak.
-impl<A: Actor> Address<A, Either> {
+impl<A> Address<A, Either> {
     /// Converts this address into a weak address.
     pub fn downgrade(&self) -> WeakAddress<A> {
         WeakAddress {
@@ -152,7 +152,7 @@ impl<A: Actor> Address<A, Either> {
 }
 
 /// Functions which apply to any kind of address, be they strong or weak.
-impl<A: Actor, Rc: RefCounter> Address<A, Rc> {
+impl<A, Rc: RefCounter> Address<A, Rc> {
     /// Returns whether the actor referred to by this address is running and accepting messages.
     ///
     /// ```rust
@@ -305,7 +305,7 @@ impl<A: Actor, Rc: RefCounter> Address<A, Rc> {
 }
 
 // Required because #[derive] adds an A: Clone bound
-impl<A: Actor, Rc: RefCounter> Clone for Address<A, Rc> {
+impl<A, Rc: RefCounter> Clone for Address<A, Rc> {
     fn clone(&self) -> Self {
         Address {
             sender: self.sender.clone(),
@@ -315,7 +315,7 @@ impl<A: Actor, Rc: RefCounter> Clone for Address<A, Rc> {
 }
 
 // Drop impls cannot be specialised, so a little bit of fanagling is used in the RefCounter impl
-impl<A: Actor, Rc: RefCounter> Drop for Address<A, Rc> {
+impl<A, Rc: RefCounter> Drop for Address<A, Rc> {
     fn drop(&mut self) {
         // We should notify the ActorManager that there are no more strong Addresses and the actor
         // should be stopped.
@@ -326,25 +326,25 @@ impl<A: Actor, Rc: RefCounter> Drop for Address<A, Rc> {
 }
 
 // Pointer identity for Address equality/comparison
-impl<A: Actor, Rc: RefCounter, Rc2: RefCounter> PartialEq<Address<A, Rc2>> for Address<A, Rc> {
+impl<A, Rc: RefCounter, Rc2: RefCounter> PartialEq<Address<A, Rc2>> for Address<A, Rc> {
     fn eq(&self, other: &Address<A, Rc2>) -> bool {
         PartialEq::eq(&self.ref_counter.as_ptr(), &other.ref_counter.as_ptr())
     }
 }
 
-impl<A: Actor, Rc: RefCounter> Eq for Address<A, Rc> {}
+impl<A, Rc: RefCounter> Eq for Address<A, Rc> {}
 
-impl<A: Actor, Rc: RefCounter, Rc2: RefCounter> PartialOrd<Address<A, Rc2>> for Address<A, Rc> {
+impl<A, Rc: RefCounter, Rc2: RefCounter> PartialOrd<Address<A, Rc2>> for Address<A, Rc> {
     fn partial_cmp(&self, other: &Address<A, Rc2>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&self.ref_counter.as_ptr(), &other.ref_counter.as_ptr())
     }
 }
-impl<A: Actor, Rc: RefCounter> Ord for Address<A, Rc> {
+impl<A, Rc: RefCounter> Ord for Address<A, Rc> {
     fn cmp(&self, other: &Self) -> Ordering {
         Ord::cmp(&self.ref_counter.as_ptr(), &other.ref_counter.as_ptr())
     }
 }
-impl<A: Actor, Rc: RefCounter> Hash for Address<A, Rc> {
+impl<A, Rc: RefCounter> Hash for Address<A, Rc> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         Hash::hash(&self.ref_counter.as_ptr(), state)
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,7 +18,7 @@ use crate::{Actor, Address, Handler, KeepRunning, Message};
 
 /// `Context` is used to control how the actor is managed and to get the actor's address from inside
 /// of a message handler.
-pub struct Context<A: Actor> {
+pub struct Context<A> {
     /// Whether the actor is running. It is changed by the `stop` method as a flag to the `ActorManager`
     /// for it to call the `stopping` method on the actor
     running: RunningState,

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -15,7 +15,7 @@ use crate::{Actor, Handler, Message};
 /// however, induce a bit of allocation (as envelopes have to be boxed).
 pub(crate) trait MessageEnvelope: Send {
     /// The type of actor that this envelope carries a message for
-    type Actor: Actor;
+    type Actor;
 
     /// Handle the message inside of the box by calling the relevant `AsyncHandler::handle` or
     /// `Handler::handle` method, returning its result over a return channel if applicable. The
@@ -130,7 +130,7 @@ impl<A: Handler<M>, M: Message + Clone + Sync> BroadcastMessageEnvelope
     }
 }
 
-impl<A: Actor> Clone for Box<dyn BroadcastMessageEnvelope<Actor = A>> {
+impl<A> Clone for Box<dyn BroadcastMessageEnvelope<Actor = A>> {
     fn clone(&self) -> Self {
         BroadcastMessageEnvelope::clone(&**self)
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -7,7 +7,7 @@ use crate::spawn::Spawner;
 use crate::Actor;
 
 /// A message that can be sent by an Address to the manage loop
-pub(crate) enum AddressMessage<A: Actor> {
+pub(crate) enum AddressMessage<A> {
     /// A message from the last address telling the actor that it should shut down
     LastAddress,
     /// A message being sent to the actor. To read about envelopes and why we use them, check out
@@ -16,14 +16,14 @@ pub(crate) enum AddressMessage<A: Actor> {
 }
 
 /// A message that can be sent by another actor on the same address to the manage loop
-pub(crate) enum BroadcastMessage<A: Actor> {
+pub(crate) enum BroadcastMessage<A> {
     /// A message from another actor on the same address telling the actor to unconditionally shut
     /// down.
     Shutdown,
     Message(Box<dyn BroadcastMessageEnvelope<Actor = A>>),
 }
 
-impl<A: Actor> Clone for BroadcastMessage<A> {
+impl<A> Clone for BroadcastMessage<A> {
     fn clone(&self) -> Self {
         use self::BroadcastMessage::*;
         match self {

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -19,12 +19,12 @@ use crate::{Actor, Handler, Message};
 /// returned by [`Address::into_sink`](../address/struct.Address.html#method.into_sink). Similarly to with
 /// addresses, the strong variety of `AddressSink` will prevent the actor from being dropped, whereas
 /// the [weak variety](struct.AddressSink.html) will not.
-pub struct AddressSink<A: Actor, Rc: RefCounter = Strong> {
+pub struct AddressSink<A: 'static, Rc: RefCounter = Strong> {
     pub(crate) sink: SendSink<'static, AddressMessage<A>>,
     pub(crate) ref_counter: Rc,
 }
 
-impl<A: Actor, Rc: RefCounter> Clone for AddressSink<A, Rc> {
+impl<A, Rc: RefCounter> Clone for AddressSink<A, Rc> {
     fn clone(&self) -> Self {
         AddressSink {
             sink: self.sink.clone(),
@@ -36,14 +36,14 @@ impl<A: Actor, Rc: RefCounter> Clone for AddressSink<A, Rc> {
 /// This variety of `AddressSink` will not prevent the actor from being dropped.
 pub type WeakAddressSink<A> = AddressSink<A, Weak>;
 
-impl<A: Actor, Rc: RefCounter> AddressSink<A, Rc> {
+impl<A, Rc: RefCounter> AddressSink<A, Rc> {
     /// Returns whether the actor referred to by this address sink is running and accepting messages.
     pub fn is_connected(&self) -> bool {
         self.ref_counter.is_connected()
     }
 }
 
-impl<A: Actor> AddressSink<A, Strong> {
+impl<A> AddressSink<A, Strong> {
     /// Create a weak address sink. Unlike with the strong variety of address sink (this kind),
     /// an actor will not be prevented from being dropped if only weak sinks, channels, and
     /// addresses exist.
@@ -55,7 +55,7 @@ impl<A: Actor> AddressSink<A, Strong> {
     }
 }
 
-impl<A: Actor, Rc: RefCounter> Drop for AddressSink<A, Rc> {
+impl<A, Rc: RefCounter> Drop for AddressSink<A, Rc> {
     fn drop(&mut self) {
         // We should notify the ActorManager that there are no more strong Addresses and the actor
         // should be stopped.
@@ -65,7 +65,7 @@ impl<A: Actor, Rc: RefCounter> Drop for AddressSink<A, Rc> {
     }
 }
 
-impl<A: Actor, Rc: RefCounter, M: Message> Sink<M> for AddressSink<A, Rc>
+impl<A, Rc: RefCounter, M: Message> Sink<M> for AddressSink<A, Rc>
 where
     A: Handler<M>,
 {


### PR DESCRIPTION
Trait bounds that are specified on structs ripple easily through
entire codebases.
In this particular case, requiring `Actor` for an `Address` is
unnecessary and makes it harder to hold on `Address` to an actor
that is represented by a type parameter.
