### PR TITLE
Mark message_channel::SendFuture as must_use

### DIFF
--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -21,6 +21,7 @@ use crate::{Handler, KeepRunning, Message};
 
 /// The future returned [`MessageChannel::send`](trait.MessageChannel.html#method.send).
 /// It resolves to `Result<M::Result, Disconnected>`.
+#[must_use]
 pub struct SendFuture<M: Message>(SendFutureInner<M>);
 
 enum SendFutureInner<M: Message> {


### PR DESCRIPTION
This way the compiler will remind us to `await` this kind of future.

It's the same QoL improvement which was introduced for `Address` in https://github.com/Restioson/xtra/pull/39.