### PR TITLE
Fixes formatting and adds missing feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,10 @@ pub mod prelude {
     pub use crate::address::Address;
     pub use crate::context::Context;
     pub use crate::message_channel::{MessageChannel, StrongMessageChannel, WeakMessageChannel};
-    #[doc(no_inline)]
-    pub use crate::{Actor, Handler, Message};
     #[cfg(feature = "with-tracing-0_1")]
     pub use crate::tracing::InstrumentedExt;
+    #[doc(no_inline)]
+    pub use crate::{Actor, Handler, Message};
 }
 
 /// A message that can be sent to an [`Actor`](trait.Actor.html) for processing. They are processed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod refcount;
 pub mod sink;
 /// This module contains a trait to spawn actors, implemented for all major async runtimes by default.
 pub mod spawn;
+#[cfg(feature = "with-tracing-0_1")]
 /// Integration with [`tracing`](https://tracing.rs).
 pub mod tracing;
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,5 +1,5 @@
-use tracing::{Instrument, Span};
 use crate::{Handler, Message};
+use tracing::{Instrument, Span};
 
 /// Instrument a message with `tracing`. This will attach the message handler span to the given
 /// `parent` span. If `IS_CHILD` is true, the message handler span will be instrumented with the
@@ -44,10 +44,12 @@ impl<A: Handler<M>, M: Message, const IS_CHILD: bool> Handler<Instrumented<M, IS
     async fn handle(
         &mut self,
         message: Instrumented<M, IS_CHILD>,
-        ctx: &mut crate::Context<Self>
+        ctx: &mut crate::Context<Self>,
     ) -> M::Result {
         if IS_CHILD {
-            self.handle(message.msg, ctx).instrument(message.parent).await
+            self.handle(message.msg, ctx)
+                .instrument(message.parent)
+                .await
         } else {
             let span = Span::current();
             span.follows_from(message.parent);


### PR DESCRIPTION
This PR fixes some minor formatting issues that `rustfmt` is complaining about and causes problems with CI.
It also adds a missing feature flag to `lib.rs`. Otherwise `master` won't compile when tracing isn't enabled.