### PR TITLE
Re-export `async_trait` from prelude

### DIFF
--- a/examples/basic_async_std.rs
+++ b/examples/basic_async_std.rs
@@ -18,7 +18,7 @@ impl Message for Print {
     type Result = ();
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;

--- a/examples/basic_smol.rs
+++ b/examples/basic_smol.rs
@@ -18,7 +18,7 @@ impl Message for Print {
     type Result = ();
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;

--- a/examples/basic_tokio.rs
+++ b/examples/basic_tokio.rs
@@ -18,7 +18,7 @@ impl Message for Print {
     type Result = ();
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;

--- a/examples/basic_wasm_bindgen/src/lib.rs
+++ b/examples/basic_wasm_bindgen/src/lib.rs
@@ -12,7 +12,7 @@ impl Message for Echo {
     type Result = String;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Echo> for Echoer {
     async fn handle(&mut self, echo: Echo, _ctx: &mut Context<Self>) -> String {
         echo.0

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -27,21 +27,21 @@ impl Message for GetCount {
     type Result = usize;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Increment> for Counter {
     async fn handle(&mut self, _: Increment, _ctx: &mut Context<Self>) {
         self.count += 1;
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<IncrementWithData> for Counter {
     async fn handle(&mut self, _: IncrementWithData, _ctx: &mut Context<Self>) {
         self.count += 1;
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<GetCount> for Counter {
     async fn handle(&mut self, _: GetCount, _ctx: &mut Context<Self>) -> usize {
         let count = self.count;
@@ -62,7 +62,7 @@ impl Message for GetTime {
     type Result = Duration;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<GetTime> for SendTimer {
     async fn handle(&mut self, _time: GetTime, _ctx: &mut Context<Self>) -> Duration {
         self.time
@@ -79,7 +79,7 @@ impl Message for TimeReturn {
     type Result = Instant;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<TimeReturn> for ReturnTimer {
     async fn handle(&mut self, _time: TimeReturn, _ctx: &mut Context<Self>) -> Instant {
         Instant::now()

--- a/examples/global_spawner_ext.rs
+++ b/examples/global_spawner_ext.rs
@@ -18,7 +18,7 @@ impl Message for Print {
     type Result = ();
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;

--- a/examples/interleaved_messages.rs
+++ b/examples/interleaved_messages.rs
@@ -16,7 +16,7 @@ struct ActorA {
 }
 impl Actor for ActorA {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Hello> for ActorA {
     async fn handle(&mut self, _: Hello, ctx: &mut Context<Self>) {
         println!("ActorA: Hello");
@@ -29,7 +29,7 @@ impl Handler<Hello> for ActorA {
 struct ActorB;
 impl Actor for ActorB {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Initialized> for ActorB {
     async fn handle(&mut self, m: Initialized, ctx: &mut Context<Self>) {
         println!("ActorB: Initialized");
@@ -38,7 +38,7 @@ impl Handler<Initialized> for ActorB {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Hello> for ActorB {
     async fn handle(&mut self, _: Hello, _: &mut Context<Self>) {
         println!("ActorB: Hello");

--- a/examples/message_stealing.rs
+++ b/examples/message_stealing.rs
@@ -19,7 +19,7 @@ impl Printer {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Printer {
     async fn stopped(self) {
         println!("Actor {} stopped", self.id);
@@ -31,7 +31,7 @@ impl Message for Print {
     type Result = ();
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     async fn handle(&mut self, print: Print, ctx: &mut Context<Self>) {
         self.times += 1;

--- a/src/address.rs
+++ b/src/address.rs
@@ -168,7 +168,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     ///     type Result = ();
     /// }
     ///
-    /// #[async_trait::async_trait]
+    /// #[async_trait]
     /// impl Handler<Shutdown> for MyActor {
     ///     async fn handle(&mut self, _: Shutdown, ctx: &mut Context<Self>) {
     ///         ctx.stop();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub mod prelude {
     pub use crate::tracing::InstrumentedExt;
     #[doc(no_inline)]
     pub use crate::{Actor, Handler, Message};
+
+    pub use async_trait::async_trait;
 }
 
 /// A message that can be sent to an [`Actor`](trait.Actor.html) for processing. They are processed
@@ -74,7 +76,7 @@ pub trait Message: Send + 'static {
 ///     type Result = u32;
 /// }
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl Handler<Msg> for MyActor {
 ///     async fn handle(&mut self, message: Msg, ctx: &mut Context<Self>) -> u32 {
 ///         20
@@ -115,7 +117,7 @@ pub trait Handler<M: Message>: Actor {
 /// # use smol::Timer;
 /// struct MyActor;
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl Actor for MyActor {
 ///     async fn started(&mut self, ctx: &mut Context<Self>) {
 ///         println!("Started!");
@@ -137,7 +139,7 @@ pub trait Handler<M: Message>: Actor {
 ///     type Result = ();
 /// }
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl Handler<Goodbye> for MyActor {
 ///     async fn handle(&mut self, _: Goodbye, ctx: &mut Context<Self>) {
 ///         println!("Goodbye!");
@@ -180,7 +182,7 @@ pub trait Actor: 'static + Send + Sized {
     /// # use xtra::prelude::*;
     /// # use xtra::KeepRunning;
     /// # struct MyActor { is_running: bool };
-    /// # #[async_trait::async_trait]
+    /// # #[async_trait]
     /// # impl Actor for MyActor {
     /// async fn stopping(&mut self, ctx: &mut Context<Self>) -> KeepRunning {
     ///     self.is_running.into() // bool can be converted to KeepRunning with Into

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -65,7 +65,7 @@ impl<M: Message> Future for SendFuture<M> {
 /// struct Alice;
 /// struct Bob;
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl Actor for Alice {
 ///     async fn stopped(self) {
 ///         println!("Oh no");
@@ -73,14 +73,14 @@ impl<M: Message> Future for SendFuture<M> {
 /// }
 /// impl Actor for Bob {}
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl Handler<WhatsYourName> for Alice {
 ///     async fn handle(&mut self, _: WhatsYourName, _ctx: &mut Context<Self>) -> &'static str {
 ///         "Alice"
 ///     }
 /// }
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl Handler<WhatsYourName> for Bob {
 ///     async fn handle(&mut self, _: WhatsYourName, _ctx: &mut Context<Self>) -> &'static str {
 ///         "Bob"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use smol_timeout::TimeoutExt;
 
 use xtra::prelude::*;


### PR DESCRIPTION
This allows downstream users to avoid declaring this dependency
separately.