### PR TITLE
Change default implementation of `Actor::stopping`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ pub trait Actor: 'static + Send + Sized {
     /// ```
     #[allow(unused_variables)]
     async fn stopping(&mut self, ctx: &mut Context<Self>) -> KeepRunning {
-        KeepRunning::StopAll
+        KeepRunning::StopSelf
     }
 
     /// Called when the actor is in the process of stopping. This could be because


### PR DESCRIPTION
Returning `StopAll` is a dangerous default because it makes supervisor
patterns hard to implement. With `StopAll`, spawning a new instance of
an actor in a context if the old one dies results in the newly created
actor to also be shut down.

See https://github.com/itchysats/itchysats/pull/1342/commits/dc5c6bdf75876f6a5db2318efb36891d4436ba7e.