### PR TITLE
Introduce `Actor::Stop`

### DIFF
--- a/examples/basic_smol.rs
+++ b/examples/basic_smol.rs
@@ -15,7 +15,7 @@ impl Printer {
 impl Actor for Printer {
     type Stop = ();
 
-    async fn stopped(self) -> Self::Stop { }
+    async fn stopped(self) -> Self::Stop {}
 }
 
 struct Print(String);

--- a/examples/basic_smol.rs
+++ b/examples/basic_smol.rs
@@ -11,7 +11,12 @@ impl Printer {
     }
 }
 
-impl Actor for Printer {}
+#[async_trait::async_trait]
+impl Actor for Printer {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop { }
+}
 
 struct Print(String);
 impl Message for Print {

--- a/examples/global_spawner_ext.rs
+++ b/examples/global_spawner_ext.rs
@@ -11,7 +11,12 @@ impl Printer {
     }
 }
 
-impl Actor for Printer {}
+#[async_trait::async_trait]
+impl Actor for Printer {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 struct Print(String);
 impl Message for Print {

--- a/examples/interleaved_messages.rs
+++ b/examples/interleaved_messages.rs
@@ -14,7 +14,13 @@ impl Message for Hello {
 struct ActorA {
     actor_b: Address<ActorB>,
 }
-impl Actor for ActorA {}
+
+#[async_trait::async_trait]
+impl Actor for ActorA {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 #[async_trait::async_trait]
 impl Handler<Hello> for ActorA {
@@ -27,7 +33,13 @@ impl Handler<Hello> for ActorA {
 }
 
 struct ActorB;
-impl Actor for ActorB {}
+
+#[async_trait::async_trait]
+impl Actor for ActorB {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 #[async_trait::async_trait]
 impl Handler<Initialized> for ActorB {

--- a/examples/message_stealing.rs
+++ b/examples/message_stealing.rs
@@ -21,6 +21,8 @@ impl Printer {
 
 #[async_trait::async_trait]
 impl Actor for Printer {
+    type Stop = ();
+
     async fn stopped(self) {
         println!("Actor {} stopped", self.id);
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -160,7 +160,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     /// # use xtra::spawn::Smol;
     /// # use std::time::Duration;
     /// # struct MyActor;
-    /// # impl Actor for MyActor {}
+    /// # #[async_trait::async_trait] impl Actor for MyActor {type Stop = (); async fn stopped(self) -> Self::Stop {} }
     /// # use smol::Timer;
     /// struct Shutdown;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub use self::address::{Address, Disconnected, WeakAddress};
 pub use self::context::{ActorShutdown, Context};
 pub use self::manager::ActorManager;
 
+pub use async_trait::async_trait;
+
 pub mod address;
 mod context;
 mod drop_notice;
@@ -67,7 +69,7 @@ pub trait Message: Send + 'static {
 /// # use xtra::prelude::*;
 /// # use xtra::spawn::Smol;
 /// # struct MyActor;
-/// # impl Actor for MyActor {}
+/// # #[async_trait::async_trait] impl Actor for MyActor {type Stop = (); async fn stopped(self) -> Self::Stop {} }
 /// struct Msg;
 ///
 /// impl Message for Msg {
@@ -117,6 +119,7 @@ pub trait Handler<M: Message>: Actor {
 ///
 /// #[async_trait::async_trait]
 /// impl Actor for MyActor {
+///     type Stop = ();
 ///     async fn started(&mut self, ctx: &mut Context<Self>) {
 ///         println!("Started!");
 ///     }
@@ -126,7 +129,7 @@ pub trait Handler<M: Message>: Actor {
 ///         KeepRunning::StopAll
 ///     }
 ///
-///     async fn stopped(self) {
+///     async fn stopped(self) -> Self::Stop {
 ///         println!("Finally stopping.");
 ///     }
 /// }
@@ -157,6 +160,9 @@ pub trait Handler<M: Message>: Actor {
 /// For longer examples, see the `examples` directory.
 #[async_trait::async_trait]
 pub trait Actor: 'static + Send + Sized {
+    /// Value returned from the actor when [`Actor::stopped`] is called.
+    type Stop: Send + 'static;
+
     /// Called as soon as the actor has been started.
     #[allow(unused_variables)]
     async fn started(&mut self, ctx: &mut Context<Self>) {}
@@ -182,9 +188,11 @@ pub trait Actor: 'static + Send + Sized {
     /// # struct MyActor { is_running: bool };
     /// # #[async_trait::async_trait]
     /// # impl Actor for MyActor {
+    /// #    type Stop = ();
     /// async fn stopping(&mut self, ctx: &mut Context<Self>) -> KeepRunning {
     ///     self.is_running.into() // bool can be converted to KeepRunning with Into
     /// }
+    /// # async fn stopped(self) -> Self::Stop { }
     /// # }
     /// ```
     #[allow(unused_variables)]
@@ -200,7 +208,7 @@ pub trait Actor: 'static + Send + Sized {
     /// [`WeakAddress`](address/type.WeakAddress.html). This should be used for any final cleanup before
     /// the actor is dropped.
     #[allow(unused_variables)]
-    async fn stopped(self) {}
+    async fn stopped(self) -> Self::Stop;
 
     /// Returns the actor's address and manager in a ready-to-start state, given the cap for the
     /// actor's mailbox. If `None` is passed, it will be of unbounded size. To spawn the actor,
@@ -214,7 +222,7 @@ pub trait Actor: 'static + Send + Sized {
     /// # use std::time::Duration;
     /// # use smol::Timer;
     /// # struct MyActor;
-    /// # impl Actor for MyActor {}
+    /// # #[async_trait::async_trait] impl Actor for MyActor {type Stop = (); async fn stopped(self) -> Self::Stop {} }
     /// smol::block_on(async {
     ///     let (addr, fut) = MyActor.create(None).run();
     ///     smol::spawn(fut).detach(); // Actually spawn the actor onto an executor

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -67,11 +67,12 @@ impl<M: Message> Future for SendFuture<M> {
 ///
 /// #[async_trait::async_trait]
 /// impl Actor for Alice {
-///     async fn stopped(self) {
+///     type Stop = ();
+///     async fn stopped(self) -> Self::Stop {
 ///         println!("Oh no");
 ///     }
 /// }
-/// impl Actor for Bob {}
+/// # #[async_trait::async_trait] impl Actor for Bob {type Stop = (); async fn stopped(self) -> Self::Stop {} }
 ///
 /// #[async_trait::async_trait]
 /// impl Handler<WhatsYourName> for Alice {

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -38,7 +38,7 @@ mod async_std_impl {
         fn spawn_global(self) -> Address<A>;
     }
 
-    impl<A: Actor> AsyncStdGlobalSpawnExt<A> for ActorManager<A> {
+    impl<A: Actor<Stop = ()>> AsyncStdGlobalSpawnExt<A> for ActorManager<A> {
         fn spawn_global(self) -> Address<A> {
             self.spawn(&mut AsyncStd)
         }
@@ -80,7 +80,7 @@ mod smol_impl {
         fn spawn_global(self) -> Address<A>;
     }
 
-    impl<A: Actor> SmolGlobalSpawnExt<A> for ActorManager<A> {
+    impl<A: Actor<Stop = ()>> SmolGlobalSpawnExt<A> for ActorManager<A> {
         fn spawn_global(self) -> Address<A> {
             self.spawn(&mut Smol::Global)
         }
@@ -121,7 +121,7 @@ mod tokio_impl {
         fn spawn_global(self) -> Address<A>;
     }
 
-    impl<A: Actor> TokioGlobalSpawnExt<A> for ActorManager<A> {
+    impl<A: Actor<Stop = ()>> TokioGlobalSpawnExt<A> for ActorManager<A> {
         fn spawn_global(self) -> Address<A> {
             self.spawn(&mut Tokio::Global)
         }
@@ -148,7 +148,7 @@ mod wasm_bindgen_impl {
         fn spawn_global(self) -> Address<A>;
     }
 
-    impl<A: Actor> WasmBindgenGlobalSpawnExt<A> for ActorManager<A> {
+    impl<A: Actor<Stop = ()>> WasmBindgenGlobalSpawnExt<A> for ActorManager<A> {
         fn spawn_global(self) -> Address<A> {
             self.spawn(&mut WasmBindgen)
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -12,7 +12,12 @@ use xtra::KeepRunning;
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Accumulator(usize);
 
-impl Actor for Accumulator {}
+#[async_trait::async_trait]
+impl Actor for Accumulator {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 struct Inc;
 impl Message for Inc {
@@ -58,6 +63,8 @@ impl Drop for DropTester {
 
 #[async_trait]
 impl Actor for DropTester {
+    type Stop = ();
+
     async fn stopping(&mut self, _ctx: &mut Context<Self>) -> KeepRunning {
         self.0.fetch_add(1, Ordering::SeqCst);
         KeepRunning::StopAll
@@ -123,7 +130,11 @@ impl Message for StreamCancelMessage {
 struct StreamCancelTester;
 
 #[async_trait]
-impl Actor for StreamCancelTester {}
+impl Actor for StreamCancelTester {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 #[async_trait]
 impl Handler<StreamCancelMessage> for StreamCancelTester {


### PR DESCRIPTION
This is useful for building supervisor patterns where the supervisor can learn, why a certain actor stopped operating. You can find our current implementation here: https://github.com/itchysats/itchysats/blob/feature/better-supervisor/xtras/src/supervisor.rs

A couple of design decisions went into this patch:

1. I chose to be Rust-stable compatible and thus, we don't have associated type-defaults. Once they become stable, we could use them.
2. I chose to require `Actor::stopped` to be implemented by every actor. This is a slight ergonomic hit but I believe it is the overall best trade-off.
a. A developer SHOULD think about why its actor is stopping.
b. If `Stop` is `()`, the method body can be empty and usually collapses into one line, hence not that big a deal really.
c. If `Stop` ever changes, the compiler will complain and lead the developer towards thinking again about what should happen in `stopped`.

We could require `Stop` to implement `Default`. I played with this idea but I think it is a foot-gun. If an actor implementation chooses to set a `Stop` value, I believe the compiler should complain at every usage that it needs to be handled. Forcing `Stop` to implement `Default` would allow things to quietly work and the value would likely get dropped somewhere.