### PR TITLE
Remove `Message` trait

### DIFF
--- a/examples/basic_smol.rs
+++ b/examples/basic_smol.rs
@@ -11,7 +11,7 @@ impl Printer {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Printer {
     type Stop = ();
 
@@ -20,7 +20,7 @@ impl Actor for Printer {
 
 struct Print(String);
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     type Return = ();
 

--- a/examples/basic_smol.rs
+++ b/examples/basic_smol.rs
@@ -19,12 +19,11 @@ impl Actor for Printer {
 }
 
 struct Print(String);
-impl Message for Print {
-    type Result = ();
-}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Print> for Printer {
+    type Return = ();
+
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;
         println!("Printing {}. Printed {} times so far.", print.0, self.times);

--- a/examples/basic_tokio.rs
+++ b/examples/basic_tokio.rs
@@ -11,7 +11,7 @@ impl Printer {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Printer {
     type Stop = ();
 

--- a/examples/basic_tokio.rs
+++ b/examples/basic_tokio.rs
@@ -11,15 +11,19 @@ impl Printer {
     }
 }
 
-impl Actor for Printer {}
+#[async_trait::async_trait]
+impl Actor for Printer {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
 
 struct Print(String);
-impl Message for Print {
-    type Result = ();
-}
 
 #[async_trait]
 impl Handler<Print> for Printer {
+    type Return = ();
+
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;
         println!("Printing {}. Printed {} times so far.", print.0, self.times);

--- a/examples/global_spawner_ext.rs
+++ b/examples/global_spawner_ext.rs
@@ -11,7 +11,7 @@ impl Printer {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Printer {
     type Stop = ();
 
@@ -20,7 +20,7 @@ impl Actor for Printer {
 
 struct Print(String);
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     type Return = ();
 

--- a/examples/global_spawner_ext.rs
+++ b/examples/global_spawner_ext.rs
@@ -19,12 +19,11 @@ impl Actor for Printer {
 }
 
 struct Print(String);
-impl Message for Print {
-    type Result = ();
-}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Print> for Printer {
+    type Return = ();
+
     async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
         self.times += 1;
         println!("Printing {}. Printed {} times so far.", print.0, self.times);

--- a/examples/interleaved_messages.rs
+++ b/examples/interleaved_messages.rs
@@ -9,14 +9,14 @@ struct ActorA {
     actor_b: Address<ActorB>,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for ActorA {
     type Stop = ();
 
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Hello> for ActorA {
     type Return = ();
 
@@ -30,14 +30,14 @@ impl Handler<Hello> for ActorA {
 
 struct ActorB;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for ActorB {
     type Stop = ();
 
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Initialized> for ActorB {
     type Return = ();
 
@@ -48,7 +48,7 @@ impl Handler<Initialized> for ActorB {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Hello> for ActorB {
     type Return = ();
 

--- a/examples/interleaved_messages.rs
+++ b/examples/interleaved_messages.rs
@@ -2,14 +2,8 @@ use xtra::prelude::*;
 use xtra::spawn::Smol;
 
 struct Initialized(Address<ActorA>);
-impl Message for Initialized {
-    type Result = ();
-}
 
 struct Hello;
-impl Message for Hello {
-    type Result = ();
-}
 
 struct ActorA {
     actor_b: Address<ActorB>,
@@ -22,8 +16,10 @@ impl Actor for ActorA {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Hello> for ActorA {
+    type Return = ();
+
     async fn handle(&mut self, _: Hello, ctx: &mut Context<Self>) {
         println!("ActorA: Hello");
         ctx.handle_while(self, self.actor_b.send(Hello))
@@ -41,8 +37,10 @@ impl Actor for ActorB {
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Initialized> for ActorB {
+    type Return = ();
+
     async fn handle(&mut self, m: Initialized, ctx: &mut Context<Self>) {
         println!("ActorB: Initialized");
         let actor_a = m.0;
@@ -50,8 +48,10 @@ impl Handler<Initialized> for ActorB {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Hello> for ActorB {
+    type Return = ();
+
     async fn handle(&mut self, _: Hello, _: &mut Context<Self>) {
         println!("ActorB: Hello");
     }

--- a/examples/message_stealing.rs
+++ b/examples/message_stealing.rs
@@ -19,7 +19,7 @@ impl Printer {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Actor for Printer {
     type Stop = ();
 
@@ -29,12 +29,11 @@ impl Actor for Printer {
 }
 
 struct Print(String);
-impl Message for Print {
-    type Result = ();
-}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Print> for Printer {
+    type Return = ();
+
     async fn handle(&mut self, print: Print, ctx: &mut Context<Self>) {
         self.times += 1;
         println!(

--- a/examples/message_stealing.rs
+++ b/examples/message_stealing.rs
@@ -19,7 +19,7 @@ impl Printer {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Printer {
     type Stop = ();
 
@@ -30,7 +30,7 @@ impl Actor for Printer {
 
 struct Print(String);
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Print> for Printer {
     type Return = ();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -379,8 +379,8 @@ impl<A: Actor> Context<A> {
     /// is only over other messages).
     pub fn notify<M>(&mut self, msg: M)
     where
-        A: Handler<M>,
         M: Send + 'static,
+        A: Handler<M>,
     {
         let envelope = Box::new(NonReturningEnvelope::<A, M>::new(msg));
         self.self_notifications.push(envelope);
@@ -411,8 +411,8 @@ impl<A: Actor> Context<A> {
     ) -> Result<impl Future<Output = ()>, ActorShutdown>
     where
         F: Send + 'static + Fn() -> M,
-        A: Handler<M>,
         M: Send + 'static,
+        A: Handler<M>,
     {
         let addr = self.address()?.downgrade();
         let mut stopped = self.drop_notifier.subscribe();
@@ -445,8 +445,8 @@ impl<A: Actor> Context<A> {
         notification: M,
     ) -> Result<impl Future<Output = ()>, ActorShutdown>
     where
-        A: Handler<M>,
         M: Send + 'static,
+        A: Handler<M>,
     {
         let addr = self.address()?.downgrade();
         let mut stopped = self.drop_notifier.subscribe();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub mod prelude {
     pub use crate::tracing::InstrumentedExt;
     #[doc(no_inline)]
     pub use crate::{Actor, Handler};
+
+    pub use async_trait::async_trait;
 }
 
 /// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
@@ -69,7 +71,7 @@ pub mod prelude {
 ///     })
 /// }
 /// ```
-#[async_trait::async_trait]
+#[async_trait]
 pub trait Handler<M>: Actor {
     /// The return value of this handler.
     type Return: Send + 'static;
@@ -140,7 +142,7 @@ pub trait Handler<M>: Actor {
 /// ```
 ///
 /// For longer examples, see the `examples` directory.
-#[async_trait::async_trait]
+#[async_trait]
 pub trait Actor: 'static + Send + Sized {
     /// Value returned from the actor when [`Actor::stopped`] is called.
     type Stop: Send + 'static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub mod prelude {
 ///     })
 /// }
 /// ```
-#[async_trait]
+#[async_trait::async_trait]
 pub trait Handler<M>: Actor {
     /// The return value of this handler.
     type Return: Send + 'static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub trait Handler<M>: Actor {
 /// ```
 ///
 /// For longer examples, see the `examples` directory.
-#[async_trait]
+#[async_trait::async_trait]
 pub trait Actor: 'static + Send + Sized {
     /// Value returned from the actor when [`Actor::stopped`] is called.
     type Stop: Send + 'static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,30 +33,7 @@ pub mod prelude {
     #[cfg(feature = "with-tracing-0_1")]
     pub use crate::tracing::InstrumentedExt;
     #[doc(no_inline)]
-    pub use crate::{Actor, Handler, Message};
-
-    pub use async_trait::async_trait;
-}
-
-/// A message that can be sent to an [`Actor`](trait.Actor.html) for processing. They are processed
-/// one at a time. Only actors implementing the corresponding [`Handler<M>`](trait.Handler.html)
-/// trait can be sent a given message.
-///
-/// # Example
-///
-/// ```no_run
-/// # use xtra::Message;
-/// struct MyResult;
-/// struct MyMessage;
-///
-/// impl Message for MyMessage {
-///     type Result = MyResult;
-/// }
-/// ```
-pub trait Message: Send + 'static {
-    /// The return type of the message. It will be returned when the [`Address::send`](address/struct.Address.html#method.send)
-    /// method is called.
-    type Result: Send;
+    pub use crate::{Actor, Handler};
 }
 
 /// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
@@ -93,12 +70,15 @@ pub trait Message: Send + 'static {
 /// }
 /// ```
 #[async_trait::async_trait]
-pub trait Handler<M: Message>: Actor {
+pub trait Handler<M>: Actor {
+    /// The return value of this handler.
+    type Return: Send + 'static;
+
     /// Handle a given message, returning its result.
     ///
     /// This is an [`async_trait`](https://docs.rs/async-trait).
     /// See the trait documentation to see an example of how this method can be declared.
-    async fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> M::Result;
+    async fn handle(&mut self, message: M, ctx: &mut Context<Self>) -> Self::Return;
 }
 
 /// An actor which can handle [`Message`s](trait.Message.html) one at a time. Actors can only be

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -280,11 +280,10 @@ where
     }
 }
 
-impl<A, M, R> StrongMessageChannel<M> for Address<A, Strong>
+impl<A, M> StrongMessageChannel<M> for Address<A, Strong>
 where
-    A: Handler<M, Return = R>,
+    A: Handler<M>,
     M: Send + 'static,
-    R: Send + 'static,
 {
     fn downgrade(&self) -> Box<dyn WeakMessageChannel<M, Return = Self::Return>> {
         Box::new(self.downgrade())
@@ -314,11 +313,10 @@ where
     }
 }
 
-impl<A, M, R> WeakMessageChannel<M> for WeakAddress<A>
+impl<A, M> WeakMessageChannel<M> for WeakAddress<A>
 where
-    A: Handler<M, Return = R>,
+    A: Handler<M>,
     M: Send + 'static,
-    R: Send + 'static,
 {
     /// Upcasts this weak message channel into a boxed generic
     /// [`MessageChannel`](trait.MessageChannel.html) trait object

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,29 +1,25 @@
-use crate::{Handler, Message};
+use crate::Handler;
 use tracing::{Instrument, Span};
 
 /// Instrument a message with `tracing`. This will attach the message handler span to the given
 /// `parent` span. If `IS_CHILD` is true, the message handler span will be instrumented with the
 ///`parent` span. Otherwise, its span will be set as following from the `parent` span.
-pub struct Instrumented<M: Message, const IS_CHILD: bool> {
+pub struct Instrumented<M, const IS_CHILD: bool> {
     /// The underlying message whose handler will be instrumented
     pub msg: M,
     /// The parent span
     pub parent: Span,
 }
 
-impl<M: Message, const IS_CHILD: bool> Message for Instrumented<M, IS_CHILD> {
-    type Result = M::Result;
-}
-
 /// Instrument a message as a child of or following from the current span.
-pub trait InstrumentedExt: Sized + Message {
+pub trait InstrumentedExt: Sized {
     /// Instrument a message as a child of the current span.
     fn instrumented_child(self) -> Instrumented<Self, true>;
     /// Instrument a message as following from the current span.
     fn instrumented_follows_from(self) -> Instrumented<Self, false>;
 }
 
-impl<M: Message> InstrumentedExt for M {
+impl<M> InstrumentedExt for M {
     fn instrumented_child(self) -> Instrumented<Self, true> {
         Instrumented {
             msg: self,
@@ -40,12 +36,18 @@ impl<M: Message> InstrumentedExt for M {
 }
 
 #[async_trait::async_trait]
-impl<A: Handler<M>, M: Message, const IS_CHILD: bool> Handler<Instrumented<M, IS_CHILD>> for A {
+impl<A, M, const IS_CHILD: bool> Handler<Instrumented<M, IS_CHILD>> for A
+where
+    A: Handler<M> + Send,
+    M: Send + 'static,
+{
+    type Return = <A as Handler<M>>::Return;
+
     async fn handle(
         &mut self,
         message: Instrumented<M, IS_CHILD>,
         ctx: &mut crate::Context<Self>,
-    ) -> M::Result {
+    ) -> Self::Return {
         if IS_CHILD {
             self.handle(message.msg, ctx)
                 .instrument(message.parent)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -19,24 +19,22 @@ impl Actor for Accumulator {
 }
 
 struct Inc;
-impl Message for Inc {
-    type Result = ();
-}
 
 struct Report;
-impl Message for Report {
-    type Result = Accumulator;
-}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Inc> for Accumulator {
+    type Return = ();
+
     async fn handle(&mut self, _: Inc, _ctx: &mut Context<Self>) {
         self.0 += 1;
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Report> for Accumulator {
+    type Return = Self;
+
     async fn handle(&mut self, _: Report, _ctx: &mut Context<Self>) -> Self {
         self.clone()
     }
@@ -60,7 +58,7 @@ impl Drop for DropTester {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Actor for DropTester {
     type Stop = ();
 
@@ -76,12 +74,10 @@ impl Actor for DropTester {
 
 struct Stop;
 
-impl Message for Stop {
-    type Result = ();
-}
-
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<Stop> for DropTester {
+    type Return = ();
+
     async fn handle(&mut self, _: Stop, ctx: &mut Context<Self>) {
         ctx.stop();
     }
@@ -122,21 +118,19 @@ async fn test_stop_and_drop() {
 
 struct StreamCancelMessage;
 
-impl Message for StreamCancelMessage {
-    type Result = KeepRunning;
-}
-
 struct StreamCancelTester;
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Actor for StreamCancelTester {
     type Stop = ();
 
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Handler<StreamCancelMessage> for StreamCancelTester {
+    type Return = KeepRunning;
+
     async fn handle(&mut self, _: StreamCancelMessage, _: &mut Context<Self>) -> KeepRunning {
         KeepRunning::Yes
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -11,7 +11,7 @@ use xtra::KeepRunning;
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Accumulator(usize);
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Accumulator {
     type Stop = ();
 
@@ -22,7 +22,7 @@ struct Inc;
 
 struct Report;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Inc> for Accumulator {
     type Return = ();
 
@@ -31,7 +31,7 @@ impl Handler<Inc> for Accumulator {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Report> for Accumulator {
     type Return = Self;
 
@@ -58,7 +58,7 @@ impl Drop for DropTester {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for DropTester {
     type Stop = ();
 
@@ -74,7 +74,7 @@ impl Actor for DropTester {
 
 struct Stop;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<Stop> for DropTester {
     type Return = ();
 
@@ -120,14 +120,14 @@ struct StreamCancelMessage;
 
 struct StreamCancelTester;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for StreamCancelTester {
     type Stop = ();
 
     async fn stopped(self) -> Self::Stop {}
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Handler<StreamCancelMessage> for StreamCancelTester {
     type Return = KeepRunning;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -179,6 +179,8 @@ impl Actor for ActorReturningStopSelf {
 
 #[async_trait]
 impl Handler<Stop> for ActorReturningStopSelf {
+    type Return = ();
+
     async fn handle(&mut self, _: Stop, ctx: &mut Context<Self>) {
         ctx.stop();
     }


### PR DESCRIPTION
We have been working with `xtra` for a while now and something that came up repeatedly is the `Message` trait. In particular, I would like to discuss the idea of removing it.

Requiring the trait to be implemented in order to declare that an actor is able to handle a message hurts ergonomics as you try to modularise a codebase that heavily depends on `xtra`. Traits can only be implemented once and the orphan rule enforces that this happens where the struct is declared.

This PR presents a Proof-of-Concept for removing the `Message` trait in favor of an associated type on the `Handler` trait. Unless I missed something, all current functionality is retained. What do you think?