### PR TITLE
Unify the `send` API on `Address` and `MessageChannel`

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,5 +1,10 @@
 # Breaking Changes by Version
 
+## Unreleased
+
+- `Context::notify_interval` and `Context::notify_after` are now subject to back-pressure.
+  These aren't API breaking but a semantic changes.
+
 ## 0.6.0
 
 - Sealed `RefCounter`, `MessageChannel`, and `MessageSink` traits

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ required-features = ["with-tokio-1", "tokio/full"]
 name = "global_spawner_ext"
 required-features = ["with-smol-1"]
 
+[[example]]
+name = "backpressure"
+required-features = ["with-tokio-1"]
+
 [[test]]
 name = "basic"
 required-features = ["with-tokio-1"]

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -47,7 +47,7 @@ fn throughput(c: &mut Criterion) {
             |b, &num_messages| {
                 b.to_async(&runtime).iter(|| async {
                     for _ in 0..num_messages - 1 {
-                        address.send(IncrementZst).split_receiver().await.unwrap();
+                        let _ = address.send(IncrementZst).split_receiver().await;
                     }
 
                     address.send(IncrementZst).await.unwrap()

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -47,7 +47,7 @@ fn throughput(c: &mut Criterion) {
             |b, &num_messages| {
                 b.to_async(&runtime).iter(|| async {
                     for _ in 0..num_messages - 1 {
-                        address.send(IncrementZst).await.unwrap();
+                        address.send(IncrementZst).recv_async().await.unwrap();
                     }
 
                     address.send(IncrementZst).await.unwrap()

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -47,7 +47,7 @@ fn throughput(c: &mut Criterion) {
             |b, &num_messages| {
                 b.to_async(&runtime).iter(|| async {
                     for _ in 0..num_messages - 1 {
-                        address.do_send(IncrementZst).unwrap();
+                        address.send(IncrementZst).await.unwrap();
                     }
 
                     address.send(IncrementZst).await.unwrap()

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -47,7 +47,7 @@ fn throughput(c: &mut Criterion) {
             |b, &num_messages| {
                 b.to_async(&runtime).iter(|| async {
                     for _ in 0..num_messages - 1 {
-                        address.send(IncrementZst).recv_async().await.unwrap();
+                        address.send(IncrementZst).split_receiver().await.unwrap();
                     }
 
                     address.send(IncrementZst).await.unwrap()

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -1,0 +1,73 @@
+use xtra::prelude::*;
+use xtra::spawn::TokioGlobalSpawnExt;
+
+struct Greeter;
+
+#[async_trait]
+impl Actor for Greeter {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+struct Hello(String);
+
+#[async_trait]
+impl Handler<Hello> for Greeter {
+    type Return = ();
+
+    async fn handle(&mut self, Hello(name): Hello, _: &mut Context<Self>) -> Self::Return {
+        println!("Hello {name}")
+    }
+}
+
+/// This examples demonstrates `xtra`'s feature of backpressure when waiting for the result of a handler asynchronously.
+///
+/// Backpressure allows an actor to throttle the sending of new messages but putting a limit on how many messages can be queued in the mailbox at once.
+/// To demonstrate backpressure we set up the following environment:
+///
+/// 1. Single-threaded tokio executor: This ensures that only one task can run at any time.
+/// 2. Call `recv_async` on the `SendFuture` returned by `Address::send`: The actor needs to be busy working off messages and thus we cannot synchronously wait for the result.
+/// 3. Print "Greeting world!" to stdout before we dispatch a message.
+/// 4. Print "Hello world!" upon executing the handler.
+///
+/// By varying the `mailbox_capacity` and observing the output on stdout, we can see the effects off backpressure:
+///
+/// ## `mailbox_capacity = Some(0)`
+///
+/// A `mailbox_capacity` of `Some(0)` will yield `Pending` on the `SendFuture` until the actor is actively requesting the next message from its event-loop.
+/// We will thus see a fairly **interleaved** pattern of:
+///
+/// - "Greeting world!"
+/// - "Hello world!"
+///
+/// This makes sense because the next "Greeting world!" can only be printed once the `SendFuture` is complete which only happens as soon as the actor is ready to take another message which in turn means it is done with processing the current message.
+///
+/// ## `mailbox_capacity = Some(N)`
+///
+/// Setting `mailbox_capacity` to `Some(N)` allows us to dispatch up to `N` message to the actor before the returned `SendFuture` returns `Pending`.
+/// We can observe this by seeing N+1 blocks of "Greeting world!".
+///
+/// The task for dispatching messages can dispatch N messages without yielding `Pending`. Due to the single-threaded executor, nothing else is executing during that time.
+/// Once the dispatching task yields `Pending`, the runtime switches to the actor's task and processes all queued messages. An empty mailbox will yield `Pending` and the
+/// entire dance starts again.
+///
+/// ## `mailbox_capacity = None`
+///
+/// A `mailbox_capacity` of `None` creates an interesting output: We only see "Greeting world!" messages.
+/// This is easily explained though. `None` creates an unbounded mailbox, meaning there is no artificial upper limit to how many messages we can queue.
+///
+/// The example ends after the loop and thus, the runtime is immediately destroyed after which means none of the queue handlers ever get to execute.
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mailbox_capacity = None;
+
+    let address = Greeter.create(mailbox_capacity).spawn_global();
+
+    for _ in 0..100 {
+        let name = format!("world!");
+
+        println!("Greeting {name}");
+        address.send(Hello(name)).recv_async().await;
+    }
+}

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -17,7 +17,7 @@ impl Handler<Hello> for Greeter {
     type Return = ();
 
     async fn handle(&mut self, Hello(name): Hello, _: &mut Context<Self>) -> Self::Return {
-        println!("Hello {name}")
+        println!("Hello {}", name)
     }
 }
 
@@ -67,7 +67,7 @@ async fn main() {
     for _ in 0..100 {
         let name = "world!".to_owned();
 
-        println!("Greeting {name}");
+        println!("Greeting {}", name);
         address.send(Hello(name)).recv_async().await;
     }
 }

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -68,6 +68,6 @@ async fn main() {
         let name = "world!".to_owned();
 
         println!("Greeting {}", name);
-        address.send(Hello(name)).recv_async().await;
+        let _ = address.send(Hello(name)).recv_async().await;
     }
 }

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -68,6 +68,6 @@ async fn main() {
         let name = "world!".to_owned();
 
         println!("Greeting {}", name);
-        let _ = address.send(Hello(name)).recv_async().await;
+        let _ = address.send(Hello(name)).split_receiver().await;
     }
 }

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -23,7 +23,7 @@ impl Handler<Hello> for Greeter {
 
 /// This examples demonstrates `xtra`'s feature of backpressure when waiting for the result of a handler asynchronously.
 ///
-/// Backpressure allows an actor to throttle the sending of new messages but putting a limit on how many messages can be queued in the mailbox at once.
+/// Backpressure allows an actor to throttle the sending of new messages by putting a limit on how many messages can be queued in the mailbox at once.
 /// To demonstrate backpressure we set up the following environment:
 ///
 /// 1. Single-threaded tokio executor: This ensures that only one task can run at any time.
@@ -31,7 +31,7 @@ impl Handler<Hello> for Greeter {
 /// 3. Print "Greeting world!" to stdout before we dispatch a message.
 /// 4. Print "Hello world!" upon executing the handler.
 ///
-/// By varying the `mailbox_capacity` and observing the output on stdout, we can see the effects off backpressure:
+/// By varying the `mailbox_capacity` and observing the output on stdout, we can see the effects of backpressure:
 ///
 /// ## `mailbox_capacity = Some(0)`
 ///
@@ -57,7 +57,7 @@ impl Handler<Hello> for Greeter {
 /// A `mailbox_capacity` of `None` creates an interesting output: We only see "Greeting world!" messages.
 /// This is easily explained though. `None` creates an unbounded mailbox, meaning there is no artificial upper limit to how many messages we can queue.
 ///
-/// The example ends after the loop and thus, the runtime is immediately destroyed after which means none of the queue handlers ever get to execute.
+/// The example ends after the loop and thus, the runtime is immediately destroyed after which means none of the queue handlers ever get to actually execute.
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let mailbox_capacity = None;

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -65,7 +65,7 @@ async fn main() {
     let address = Greeter.create(mailbox_capacity).spawn_global();
 
     for _ in 0..100 {
-        let name = format!("world!");
+        let name = "world!".to_owned();
 
         println!("Greeting {name}");
         address.send(Hello(name)).recv_async().await;

--- a/examples/message_stealing.rs
+++ b/examples/message_stealing.rs
@@ -48,13 +48,14 @@ impl Handler<Print> for Printer {
     }
 }
 
-fn main() {
+#[smol_potat::main]
+async fn main() {
     let (addr, mut ctx) = Context::new(Some(32));
     for n in 0..4 {
         smol::spawn(ctx.attach(Printer::new(n))).detach();
     }
 
-    while addr.do_send(Print("hello".to_string())).is_ok() {}
+    while addr.send(Print("hello".to_string())).await.is_ok() {}
     println!("Stopping to send");
 
     // Give a second for everything to shut down

--- a/src/address.rs
+++ b/src/address.rs
@@ -133,10 +133,12 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
         }
     }
 
-    // TODO: Revise these docs.
-    /// Send a [`Message`](../trait.Message.html) to the actor and asynchronously wait for a response. If this
-    /// returns `Err(Disconnected)`, then the actor is stopped and not accepting messages. Like most
-    /// futures, this must be polled to actually send the message.
+    /// Send a message to the actor.
+    ///
+    /// The actor must implement [`Handler<Message>`] for this to work.
+    ///
+    /// This function returns a [`Future`](SendFuture) that resolves to the [`Return`](crate::Handler::Return) value of the handler.
+    /// The [`SendFuture`] will resolve to [`Err(Disconnected)`] in case the actor is stopped and not accepting messages.
     #[allow(clippy::type_complexity)] // TODO: Actually fix this
     pub fn send<M>(
         &self,

--- a/src/address.rs
+++ b/src/address.rs
@@ -31,6 +31,13 @@ pub struct SendFuture<A: Actor, R, TRecvSyncMarker> {
     phantom: PhantomData<TRecvSyncMarker>,
 }
 
+enum SendFutureInner<A: Actor, R> {
+    Disconnected,
+    Sending(ChannelSendFuture<'static, AddressMessage<A>>, Receiver<R>),
+    Receiving(Receiver<R>),
+    Done,
+}
+
 impl<A: Actor, R> SendFuture<A, R, ReceiveSync> {
     fn sending(
         send_fut: ChannelSendFuture<'static, AddressMessage<A>>,
@@ -56,13 +63,6 @@ impl<A: Actor, R> SendFuture<A, R, ReceiveSync> {
             phantom: PhantomData,
         }
     }
-}
-
-enum SendFutureInner<A: Actor, R> {
-    Disconnected,
-    Sending(ChannelSendFuture<'static, AddressMessage<A>>, Receiver<R>),
-    Receiving(Receiver<R>),
-    Done,
 }
 
 impl<A: Actor, R> Future for SendFuture<A, R, ReceiveSync> {

--- a/src/address.rs
+++ b/src/address.rs
@@ -12,9 +12,9 @@ use futures_util::{future, StreamExt};
 use crate::envelope::ReturningEnvelope;
 use crate::manager::AddressMessage;
 use crate::refcount::{Either, RefCounter, Strong, Weak};
-use crate::send_future::{NameableSending, SendFuture};
+use crate::send_future::{NameableSending, ReceiveSync, SendFuture};
 use crate::sink::AddressSink;
-use crate::{Handler, KeepRunning, ReceiveSync};
+use crate::{Handler, KeepRunning};
 
 /// The actor is no longer running and disconnected from the sending address. For why this could
 /// occur, see the [`Actor::stopping`](../trait.Actor.html#method.stopping) and

--- a/src/address.rs
+++ b/src/address.rs
@@ -139,7 +139,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     ///
     /// This function returns a [`Future`](SendFuture) that resolves to the [`Return`](crate::Handler::Return) value of the handler.
     /// The [`SendFuture`] will resolve to [`Err(Disconnected)`] in case the actor is stopped and not accepting messages.
-    #[allow(clippy::type_complexity)] // TODO: Actually fix this
+    #[allow(clippy::type_complexity)]
     pub fn send<M>(
         &self,
         message: M,

--- a/src/address.rs
+++ b/src/address.rs
@@ -12,7 +12,7 @@ use futures_util::{future, StreamExt};
 use crate::envelope::ReturningEnvelope;
 use crate::manager::AddressMessage;
 use crate::refcount::{Either, RefCounter, Strong, Weak};
-use crate::send_future::{ResolveToHandlerReturn, NameableSending, SendFuture};
+use crate::send_future::{NameableSending, ResolveToHandlerReturn, SendFuture};
 use crate::sink::AddressSink;
 use crate::{Handler, KeepRunning};
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -137,6 +137,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     /// Send a [`Message`](../trait.Message.html) to the actor and asynchronously wait for a response. If this
     /// returns `Err(Disconnected)`, then the actor is stopped and not accepting messages. Like most
     /// futures, this must be polled to actually send the message.
+    #[allow(clippy::type_complexity)] // TODO: Actually fix this
     pub fn send<M>(
         &self,
         message: M,

--- a/src/address.rs
+++ b/src/address.rs
@@ -12,7 +12,7 @@ use futures_util::{future, StreamExt};
 use crate::envelope::ReturningEnvelope;
 use crate::manager::AddressMessage;
 use crate::refcount::{Either, RefCounter, Strong, Weak};
-use crate::send_future::{NameableSending, ReceiveSync, SendFuture};
+use crate::send_future::{ResolveToHandlerReturn, NameableSending, SendFuture};
 use crate::sink::AddressSink;
 use crate::{Handler, KeepRunning};
 
@@ -146,7 +146,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     ) -> SendFuture<
         <A as Handler<M>>::Return,
         NameableSending<A, <A as Handler<M>>::Return>,
-        ReceiveSync,
+        ResolveToHandlerReturn,
     >
     where
         M: Send + 'static,

--- a/src/context.rs
+++ b/src/context.rs
@@ -403,6 +403,10 @@ impl<A: Actor> Context<A> {
     /// Notify the actor with a message every interval until it is stopped (either directly with
     /// [`Context::stop`](struct.Context.html#method.stop), or for a lack of strong
     /// [`Address`es](address/struct.Address.html)). This does not take priority over other messages.
+    ///
+    /// This function is subject to back-pressure by the actor's mailbox. Thus, if the mailbox is full
+    /// the loop will wait until a slot is available. It is therefore not guaranteed that a message
+    /// will be delivered at exactly `duration` intervals.
     #[cfg(feature = "timing")]
     pub fn notify_interval<F, M>(
         &mut self,
@@ -439,6 +443,9 @@ impl<A: Actor> Context<A> {
 
     /// Notify the actor with a message after a certain duration has elapsed. This does not take
     /// priority over other messages.
+    ///
+    /// This function is subject to back-pressure by the actor's mailbox. If the mailbox is full once
+    /// the timer expires, the future will continue to block until the message is delivered.
     pub fn notify_after<M>(
         &mut self,
         duration: Duration,

--- a/src/context.rs
+++ b/src/context.rs
@@ -422,7 +422,7 @@ impl<A: Actor> Context<A> {
                 let delay = Delay::new(duration);
                 match future::select(delay, &mut stopped).await {
                     Either::Left(_) => {
-                        if addr.do_send(constructor()).is_err() {
+                        if addr.send(constructor()).await.is_err() {
                             break;
                         }
                     }
@@ -455,7 +455,7 @@ impl<A: Actor> Context<A> {
             let delay = Delay::new(duration);
             match future::select(delay, &mut stopped).await {
                 Either::Left(_) => {
-                    let _ = addr.do_send(notification);
+                    let _ = addr.send(notification).await;
                 }
                 Either::Right(_) => {
                     // Context stopped before the end of the delay was reached

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod drop_notice;
 mod envelope;
 mod manager;
 pub mod message_channel;
+mod receiver;
 /// This module contains types representing the strength of an address's reference counting, which
 /// influences whether the address will keep the actor alive for as long as it lives.
 pub mod refcount;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,12 @@ pub mod prelude {
     pub use async_trait::async_trait;
 }
 
+/// TODO: docs
+pub enum ReceiveSync {}
+
+/// TODO: docs
+pub enum ReceiveAsync {}
+
 /// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
 /// asynchronously, and the logic to handle the message.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod receiver;
 /// This module contains types representing the strength of an address's reference counting, which
 /// influences whether the address will keep the actor alive for as long as it lives.
 pub mod refcount;
+mod send_future;
 pub mod sink;
 /// This module contains a trait to spawn actors, implemented for all major async runtimes by default.
 pub mod spawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 pub use self::address::{Address, Disconnected, WeakAddress};
 pub use self::context::{ActorShutdown, Context};
 pub use self::manager::ActorManager;
+pub use self::receiver::Receiver;
+pub use self::send_future::SendFuture;
 
 pub mod address;
 mod context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,12 +38,6 @@ pub mod prelude {
     pub use async_trait::async_trait;
 }
 
-/// TODO: docs
-pub enum ReceiveSync {}
-
-/// TODO: docs
-pub enum ReceiveAsync {}
-
 /// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
 /// asynchronously, and the logic to handle the message.
 ///

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -234,7 +234,7 @@ where
     where
         R: Into<KeepRunning> + Send,
     {
-        Box::pin(self.attach_stream(stream))
+        Box::pin(Address::attach_stream(self, stream))
     }
 
     fn clone_channel(&self) -> Box<dyn MessageChannel<M, Return = Self::Return>> {

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 
 use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
-use futures_util::{FutureExt};
+use futures_util::FutureExt;
 
 use crate::address::{Address, Disconnected, WeakAddress};
 use crate::envelope::ReturningEnvelope;

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -11,9 +11,9 @@ use crate::manager::AddressMessage;
 use crate::private::Sealed;
 use crate::receiver::Receiver;
 use crate::refcount::{RefCounter, Shared, Strong};
-use crate::send_future::SendFuture;
+use crate::send_future::{ReceiveSync, SendFuture};
 use crate::sink::{AddressSink, MessageSink, StrongMessageSink, WeakMessageSink};
-use crate::{Handler, KeepRunning, ReceiveSync};
+use crate::{Handler, KeepRunning};
 
 /// A message channel is a channel through which you can send only one kind of message, but to
 /// any actor that can handle it. It is like [`Address`](../address/struct.Address.html), but associated with

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -211,7 +211,10 @@ where
         self.capacity()
     }
 
-    fn send(&self, message: M) -> SendFuture<R, BoxFuture<'static, Receiver<R>>, ResolveToHandlerReturn> {
+    fn send(
+        &self,
+        message: M,
+    ) -> SendFuture<R, BoxFuture<'static, Receiver<R>>, ResolveToHandlerReturn> {
         if self.is_connected() {
             let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
             let sending = self

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -11,7 +11,7 @@ use crate::manager::AddressMessage;
 use crate::private::Sealed;
 use crate::receiver::Receiver;
 use crate::refcount::{RefCounter, Shared, Strong};
-use crate::send_future::{ReceiveSync, SendFuture};
+use crate::send_future::{ResolveToHandlerReturn, SendFuture};
 use crate::sink::{AddressSink, MessageSink, StrongMessageSink, WeakMessageSink};
 use crate::{Handler, KeepRunning};
 
@@ -108,7 +108,7 @@ pub trait MessageChannel<M>: Sealed + Unpin + Send + Sync {
     fn send(
         &self,
         message: M,
-    ) -> SendFuture<Self::Return, BoxFuture<'static, Receiver<Self::Return>>, ReceiveSync>;
+    ) -> SendFuture<Self::Return, BoxFuture<'static, Receiver<Self::Return>>, ResolveToHandlerReturn>;
 
     /// Attaches a stream to this channel such that all messages produced by it are forwarded to the
     /// actor. This could, for instance, be used to forward messages from a socket to the actor
@@ -211,7 +211,7 @@ where
         self.capacity()
     }
 
-    fn send(&self, message: M) -> SendFuture<R, BoxFuture<'static, Receiver<R>>, ReceiveSync> {
+    fn send(&self, message: M) -> SendFuture<R, BoxFuture<'static, Receiver<R>>, ResolveToHandlerReturn> {
         if self.is_connected() {
             let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
             let sending = self

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -99,11 +99,12 @@ pub trait MessageChannel<M>: Sealed + Unpin + Send + Sync {
         self.len() == 0
     }
 
-    // TODO: Revise these docs.
-    /// Send a [`Message`](../trait.Message.html) to the actor and asynchronously wait for a response. If this
-    /// returns `Err(Disconnected)`, then the actor is stopped and not accepting messages. This,
-    /// unlike [`Address::send`](../address/struct.Address.html#method.send) will block if the actor's mailbox
-    /// is full. If this is undesired, consider using a [`MessageSink`](../sink/trait.MessageSink.html).
+    /// Send a message to the actor.
+    ///
+    /// The actor must implement [`Handler<Message>`] for this to work.
+    ///
+    /// This function returns a [`Future`](SendFuture) that resolves to the [`Return`](crate::Handler::Return) value of the handler.
+    /// The [`SendFuture`] will resolve to [`Err(Disconnected)`] in case the actor is stopped and not accepting messages.
     fn send(
         &self,
         message: M,

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -9,6 +9,7 @@ use std::task::{Context, Poll};
 /// A [`Future`] that resolves to the [`Return`](crate::Handler::Return) value of a [`Handler`](crate::Handler).
 ///
 /// In case the actor becomes disconnected during the execution of the handler, this future will resolve to [`Disconnected`].
+#[must_use = "Futures do nothing unless polled"]
 pub struct Receiver<R> {
     inner: Inner<R>,
 }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -39,16 +39,16 @@ impl<R> Future for Receiver<R> {
         match mem::replace(&mut this.inner, Inner::Done) {
             Inner::Disconnected => {
                 this.inner = Inner::Done;
-                return Poll::Ready(Err(Disconnected));
+                Poll::Ready(Err(Disconnected))
             }
             Inner::Receiving(mut rx) => match rx.poll_unpin(cx) {
                 Poll::Ready(item) => {
                     this.inner = Inner::Done;
-                    return Poll::Ready(item);
+                    Poll::Ready(item)
                 }
                 Poll::Pending => {
                     this.inner = Inner::Receiving(rx);
-                    return Poll::Pending;
+                    Poll::Pending
                 }
             },
             Inner::Done => panic!("Polled after completion"),

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -39,18 +39,15 @@ impl<R> Future for Receiver<R> {
         match mem::replace(&mut this.inner, Inner::Done) {
             Inner::Disconnected => {
                 this.inner = Inner::Done;
-
                 return Poll::Ready(Err(Disconnected));
             }
             Inner::Receiving(mut rx) => match rx.poll_unpin(cx) {
                 Poll::Ready(item) => {
                     this.inner = Inner::Done;
-
                     return Poll::Ready(item);
                 }
                 Poll::Pending => {
                     this.inner = Inner::Receiving(rx);
-
                     return Poll::Pending;
                 }
             },

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,0 +1,60 @@
+use crate::Disconnected;
+use futures_util::future::MapErr;
+use futures_util::{FutureExt, TryFutureExt};
+use std::future::Future;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub struct Receiver<R> {
+    inner: Inner<R>,
+}
+
+impl<R> Receiver<R> {
+    pub(crate) fn disconnected() -> Self {
+        Self {
+            inner: Inner::Disconnected,
+        }
+    }
+
+    pub(crate) fn new(receiver: catty::Receiver<R>) -> Self {
+        Self {
+            inner: Inner::Receiving(receiver.map_err(|_| Disconnected)),
+        }
+    }
+}
+
+enum Inner<R> {
+    Disconnected,
+    Receiving(MapErr<catty::Receiver<R>, fn(catty::Disconnected) -> Disconnected>),
+    Done,
+}
+
+impl<R> Future for Receiver<R> {
+    type Output = Result<R, Disconnected>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        match mem::replace(&mut this.inner, Inner::Done) {
+            Inner::Disconnected => {
+                this.inner = Inner::Done;
+
+                return Poll::Ready(Err(Disconnected));
+            }
+            Inner::Receiving(mut rx) => match rx.poll_unpin(cx) {
+                Poll::Ready(item) => {
+                    this.inner = Inner::Done;
+
+                    return Poll::Ready(item);
+                }
+                Poll::Pending => {
+                    this.inner = Inner::Receiving(rx);
+
+                    return Poll::Pending;
+                }
+            },
+            Inner::Done => panic!("Polled after completion"),
+        }
+    }
+}

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -6,6 +6,9 @@ use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+/// A [`Future`] that resolves to the [`Return`](crate::Handler::Return) value of a [`Handler`](crate::Handler).
+///
+/// In case the actor becomes disconnected during the execution of the handler, this future will resolve to [`Disconnected`].
 pub struct Receiver<R> {
     inner: Inner<R>,
 }

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -1,6 +1,6 @@
 use crate::manager::AddressMessage;
 use crate::receiver::Receiver;
-use crate::{Disconnected, ReceiveAsync, ReceiveSync};
+use crate::Disconnected;
 use flume::r#async::SendFut;
 use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
@@ -16,6 +16,12 @@ pub struct SendFuture<R, F, TRecvSyncMarker> {
     inner: SendFutureInner<R, F>,
     phantom: PhantomData<TRecvSyncMarker>,
 }
+
+/// TODO: docs
+pub enum ReceiveSync {}
+
+/// TODO: docs
+pub enum ReceiveAsync {}
 
 enum SendFutureInner<R, F> {
     Disconnected,

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -16,7 +16,7 @@ use std::task::{Context, Poll};
 /// This behaviour can be changed by calling [`recv_async`](SendFuture::recv_async).
 ///
 /// When toggled to receive the return value asynchronously, this future will not resolve until the message is successfully queued into the actor's mailbox. If the actors mailbox is bounded, this future will yield until there is space in the mailbox.
-#[must_use]
+#[must_use = "Futures do nothing unless polled"]
 pub struct SendFuture<R, F, TRecvSyncMarker> {
     inner: SendFutureInner<R, F>,
     phantom: PhantomData<TRecvSyncMarker>,

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -1,0 +1,165 @@
+use crate::manager::AddressMessage;
+use crate::receiver::Receiver;
+use crate::{Disconnected, ReceiveAsync, ReceiveSync};
+use flume::r#async::SendFut;
+use futures_core::future::BoxFuture;
+use futures_util::FutureExt;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// TODO docs
+#[must_use]
+pub struct SendFuture<R, F, TRecvSyncMarker> {
+    inner: SendFutureInner<R, F>,
+    phantom: PhantomData<TRecvSyncMarker>,
+}
+
+enum SendFutureInner<R, F> {
+    Disconnected,
+    Sending(F),
+    Receiving(Receiver<R>),
+    Done,
+}
+
+impl<R, F> SendFuture<R, F, ReceiveSync> {
+    pub(crate) fn disconnected() -> Self {
+        Self {
+            inner: SendFutureInner::Disconnected,
+            phantom: PhantomData,
+        }
+    }
+
+    /// TODO: docs
+    pub fn recv_async(self) -> SendFuture<R, F, ReceiveAsync> {
+        SendFuture {
+            inner: self.inner,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<R> SendFuture<R, BoxFuture<'static, Receiver<R>>, ReceiveSync> {
+    pub(crate) fn sending_boxed<F>(send_fut: F) -> Self
+    where
+        F: Future<Output = Receiver<R>> + Send + 'static,
+    {
+        Self {
+            inner: SendFutureInner::Sending(send_fut.boxed()),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, R> SendFuture<R, NameableSending<A, R>, ReceiveSync> {
+    pub(crate) fn sending_named(
+        send_fut: SendFut<'static, AddressMessage<A>>,
+        receiver: catty::Receiver<R>,
+    ) -> Self {
+        Self {
+            inner: SendFutureInner::Sending(NameableSending {
+                inner: send_fut,
+                receiver: Some(Receiver::new(receiver)),
+            }),
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub struct NameableSending<A: 'static, R> {
+    inner: SendFut<'static, AddressMessage<A>>,
+    receiver: Option<Receiver<R>>,
+}
+
+impl<A, R> Future for NameableSending<A, R> {
+    type Output = Receiver<R>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        let result = futures_util::ready!(this.inner.poll_unpin(cx));
+
+        match result {
+            Ok(()) => Poll::Ready(this.receiver.take().expect("polled after completion")),
+            Err(_) => Poll::Ready(Receiver::disconnected()),
+        }
+    }
+}
+
+impl<R, F> Future for SendFuture<R, F, ReceiveSync>
+where
+    F: Future<Output = Receiver<R>> + Unpin,
+{
+    type Output = Result<R, Disconnected>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        match mem::replace(&mut this.inner, SendFutureInner::Done) {
+            SendFutureInner::Disconnected => {
+                this.inner = SendFutureInner::Done;
+                Poll::Ready(Err(Disconnected))
+            }
+            SendFutureInner::Sending(mut send_fut) => match send_fut.poll_unpin(ctx) {
+                Poll::Ready(rx) => {
+                    this.inner = SendFutureInner::Receiving(rx);
+                    this.poll_unpin(ctx)
+                }
+                Poll::Pending => {
+                    this.inner = SendFutureInner::Sending(send_fut);
+                    Poll::Pending
+                }
+            },
+            SendFutureInner::Receiving(mut rx) => match rx.poll_unpin(ctx) {
+                Poll::Ready(item) => {
+                    this.inner = SendFutureInner::Done;
+                    Poll::Ready(item)
+                }
+                Poll::Pending => {
+                    this.inner = SendFutureInner::Receiving(rx);
+                    Poll::Pending
+                }
+            },
+            SendFutureInner::Done => {
+                panic!("Polled after completion")
+            }
+        }
+    }
+}
+
+impl<R, F> Future for SendFuture<R, F, ReceiveAsync>
+where
+    F: Future<Output = Receiver<R>> + Unpin,
+{
+    type Output = Receiver<R>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        match mem::replace(&mut this.inner, SendFutureInner::Done) {
+            SendFutureInner::Disconnected => {
+                this.inner = SendFutureInner::Done;
+                Poll::Ready(Receiver::disconnected())
+            }
+            SendFutureInner::Sending(mut send_fut) => match send_fut.poll_unpin(ctx) {
+                Poll::Ready(rx) => {
+                    this.inner = SendFutureInner::Receiving(rx);
+                    this.poll_unpin(ctx)
+                }
+                Poll::Pending => {
+                    this.inner = SendFutureInner::Sending(send_fut);
+                    Poll::Pending
+                }
+            },
+            SendFutureInner::Receiving(rx) => {
+                this.inner = SendFutureInner::Done;
+                Poll::Ready(rx)
+            }
+            SendFutureInner::Done => {
+                panic!("Polled after completion")
+            }
+        }
+    }
+}

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -10,12 +10,12 @@ use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// A [`Future`] that represents state of sending a message to an actor.
+/// A [`Future`] that represents the state of sending a message to an actor.
 ///
 /// By default, a `SendFuture` will also wait until the handler has finished executing and resolve to the return value (see [`Handler::Return`](crate::Handler::Return)).
 /// This behaviour can be changed by calling [`recv_async`](SendFuture::recv_async).
 ///
-/// When toggled to receive the return value asynchronously, this future will not resolve until the message is successfully queued into the actor's mailbox. If the actors mailbox is bounded, this future will yield until there is space in the mailbox.
+/// When toggled to receive the return value asynchronously, this future will resolve once the message is successfully queued into the actor's mailbox. If the actors mailbox is bounded, this future will yield `Pending` until there is space in the mailbox. This allows an actor to exercise backpressure on its users.
 #[must_use = "Futures do nothing unless polled"]
 pub struct SendFuture<R, F, TRecvSyncMarker> {
     inner: SendFutureInner<R, F>,
@@ -43,7 +43,7 @@ impl<R, F> SendFuture<R, F, ReceiveSync> {
         }
     }
 
-    /// Toggle this future to only queue the message into the actor's mailbox.
+    /// Toggle this future to receive the return value asynchronously.
     ///
     /// Calling this function will change the [`Output`](Future::Output) of this [`Future`] from [`Handler::Return`](crate::Handler::Return) to [`Receiver<Handler::Return>`](Receiver<crate::Handler::Return>).
     ///

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -213,7 +213,9 @@ async fn receiving_async_on_address_returns_immediately_after_dispatch() {
     let address = LongRunningHandler.create(None).spawn_global();
 
     let send_future = address.send(Duration::from_secs(3)).recv_async();
-    let handler_future = send_future.now_or_never().expect("Dispatch should be immediate on first poll");
+    let handler_future = send_future
+        .now_or_never()
+        .expect("Dispatch should be immediate on first poll");
 
     handler_future.await.unwrap();
 }
@@ -224,7 +226,9 @@ async fn receiving_async_on_message_channel_returns_immediately_after_dispatch()
     let channel = StrongMessageChannel::clone_channel(&address);
 
     let send_future = channel.send(Duration::from_secs(3)).recv_async();
-    let handler_future = send_future.now_or_never().expect(Dispatch should be immediate on first poll");
+    let handler_future = send_future
+        .now_or_never()
+        .expect("Dispatch should be immediate on first poll");
 
     handler_future.await.unwrap();
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -212,7 +212,7 @@ impl Handler<Duration> for LongRunningHandler {
 async fn receiving_async_on_address_returns_immediately_after_dispatch() {
     let address = LongRunningHandler.create(None).spawn_global();
 
-    let send_future = address.send(Duration::from_secs(3)).recv_async();
+    let send_future = address.send(Duration::from_secs(3)).split_receiver();
     let handler_future = send_future
         .now_or_never()
         .expect("Dispatch should be immediate on first poll");
@@ -259,10 +259,10 @@ async fn address_send_exercises_backpressure() {
 
     let _ = address
         .send(Hello("world"))
-        .recv_async()
+        .split_receiver()
         .now_or_never()
         .expect("be able to queue 1 message because the mailbox is empty");
-    let handler2 = address.send(Hello("world")).recv_async().now_or_never();
+    let handler2 = address.send(Hello("world")).split_receiver().now_or_never();
     assert!(
         handler2.is_none(),
         "Fail to queue 2nd message because mailbox is full"
@@ -272,7 +272,7 @@ async fn address_send_exercises_backpressure() {
 
     let _ = address
         .send(Hello("world"))
-        .recv_async()
+        .split_receiver()
         .now_or_never()
         .expect("be able to queue another message because the mailbox is empty again");
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -245,7 +245,7 @@ impl Handler<Hello> for Greeter {
     type Return = String;
 
     async fn handle(&mut self, Hello(name): Hello, _: &mut Context<Self>) -> Self::Return {
-        format!("Hello {name}")
+        format!("Hello {}", name)
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -213,7 +213,7 @@ async fn receiving_async_on_address_returns_immediately_after_dispatch() {
     let address = LongRunningHandler.create(None).spawn_global();
 
     let send_future = address.send(Duration::from_secs(3)).recv_async();
-    let handler_future = send_future.now_or_never().unwrap(); // Dispatch should be immediate on first poll!
+    let handler_future = send_future.now_or_never().expect("Dispatch should be immediate on first poll");
 
     handler_future.await.unwrap();
 }
@@ -224,7 +224,7 @@ async fn receiving_async_on_message_channel_returns_immediately_after_dispatch()
     let channel = StrongMessageChannel::clone_channel(&address);
 
     let send_future = channel.send(Duration::from_secs(3)).recv_async();
-    let handler_future = send_future.now_or_never().unwrap(); // Dispatch should be immediate on first poll!
+    let handler_future = send_future.now_or_never().expect(Dispatch should be immediate on first poll");
 
     handler_future.await.unwrap();
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -253,7 +253,7 @@ impl Handler<Hello> for Greeter {
 async fn address_send_exercises_backpressure() {
     let (address, mut context) = Context::new(Some(1));
 
-    address
+    let _ = address
         .send(Hello("world"))
         .recv_async()
         .now_or_never()
@@ -266,7 +266,7 @@ async fn address_send_exercises_backpressure() {
 
     context.yield_once(&mut Greeter).await; // process one message
 
-    address
+    let _ = address
         .send(Hello("world"))
         .recv_async()
         .now_or_never()

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,3 +1,4 @@
+use futures_util::FutureExt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -44,7 +45,7 @@ impl Handler<Report> for Accumulator {
 async fn accumulate_to_ten() {
     let addr = Accumulator(0).create(None).spawn_global();
     for _ in 0..10 {
-        addr.do_send(Inc).unwrap();
+        addr.send(Inc).await.unwrap();
     }
 
     assert_eq!(addr.send(Report).await.unwrap().0, 10);
@@ -97,7 +98,7 @@ async fn test_stop_and_drop() {
     let drop_count = Arc::new(AtomicUsize::new(0));
     let (addr, fut) = DropTester(drop_count.clone()).create(None).run();
     let handle = smol::spawn(fut);
-    addr.do_send(Stop).unwrap();
+    addr.send(Stop).await.unwrap();
     handle.await;
     assert_eq!(drop_count.load(Ordering::SeqCst), 3);
 
@@ -111,7 +112,10 @@ async fn test_stop_and_drop() {
     // Send a stop message before future has even begun
     let drop_count = Arc::new(AtomicUsize::new(0));
     let (addr, fut) = DropTester(drop_count.clone()).create(None).run();
-    addr.do_send(Stop).unwrap();
+    smol::spawn(async move {
+        addr.send(Stop).await.unwrap();
+    })
+    .detach();
     smol::spawn(fut).await;
     assert_eq!(drop_count.load(Ordering::SeqCst), 3);
 }
@@ -184,4 +188,43 @@ impl Handler<Stop> for ActorReturningStopSelf {
     async fn handle(&mut self, _: Stop, ctx: &mut Context<Self>) {
         ctx.stop();
     }
+}
+
+struct LongRunningHandler;
+
+#[async_trait]
+impl Actor for LongRunningHandler {
+    type Stop = ();
+
+    async fn stopped(self) -> Self::Stop {}
+}
+
+#[async_trait]
+impl Handler<Duration> for LongRunningHandler {
+    type Return = ();
+
+    async fn handle(&mut self, duration: Duration, _: &mut Context<Self>) -> Self::Return {
+        tokio::time::sleep(duration).await
+    }
+}
+
+#[tokio::test]
+async fn receiving_async_on_address_returns_immediately_after_dispatch() {
+    let address = LongRunningHandler.create(None).spawn_global();
+
+    let send_future = address.send(Duration::from_secs(3)).recv_async();
+    let handler_future = send_future.now_or_never().unwrap(); // Dispatch should be immediate on first poll!
+
+    handler_future.await.unwrap();
+}
+
+#[tokio::test]
+async fn receiving_async_on_message_channel_returns_immediately_after_dispatch() {
+    let address = LongRunningHandler.create(None).spawn_global();
+    let channel = StrongMessageChannel::clone_channel(&address);
+
+    let send_future = channel.send(Duration::from_secs(3)).recv_async();
+    let handler_future = send_future.now_or_never().unwrap(); // Dispatch should be immediate on first poll!
+
+    handler_future.await.unwrap();
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -253,11 +253,22 @@ impl Handler<Hello> for Greeter {
 async fn address_send_exercises_backpressure() {
     let (address, mut context) = Context::new(Some(1));
 
-    address.send(Hello("world")).recv_async().now_or_never().expect("be able to queue 1 message because the mailbox is empty");
+    address
+        .send(Hello("world"))
+        .recv_async()
+        .now_or_never()
+        .expect("be able to queue 1 message because the mailbox is empty");
     let handler2 = address.send(Hello("world")).recv_async().now_or_never();
-    assert!(handler2.is_none(), "Fail to queue 2nd message because mailbox is full");
+    assert!(
+        handler2.is_none(),
+        "Fail to queue 2nd message because mailbox is full"
+    );
 
     context.yield_once(&mut Greeter).await; // process one message
 
-    address.send(Hello("world")).recv_async().now_or_never().expect("be able to queue another message because the mailbox is empty again");
+    address
+        .send(Hello("world"))
+        .recv_async()
+        .now_or_never()
+        .expect("be able to queue another message because the mailbox is empty again");
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -225,7 +225,7 @@ async fn receiving_async_on_message_channel_returns_immediately_after_dispatch()
     let address = LongRunningHandler.create(None).spawn_global();
     let channel = StrongMessageChannel::clone_channel(&address);
 
-    let send_future = channel.send(Duration::from_secs(3)).recv_async();
+    let send_future = channel.send(Duration::from_secs(3)).split_receiver();
     let handler_future = send_future
         .now_or_never()
         .expect("Dispatch should be immediate on first poll");


### PR DESCRIPTION
This PR presents a unified API for sending messages to actors. We now only have a single `send` function on both `Address` and `MessageChannel` and we return the same `SendFuture` type in both cases.

The `SendFuture` type has a single, publicly accessible function called `recv_async` which allows users to flip the behaviour of `SendFuture` from synchronously awaiting the handler's result to returning a `Receiver` that can be awaited separately.

This allows users to _queue_ messages into an actor's mailbox without awaiting the result. As part of merging the two existing `SendFuture` types, we now also provide a consistent "backpressure" story: A `SendFuture` that is flipped to receiving the result asynchronously will only complete once the message has been successfully queued into the actor's mailbox. I've added an example that demonstrates this and also a test that make sure we don't break this functionality in the future.