### PR TITLE
Type-safe actor lifecycle

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -165,13 +165,6 @@ impl<A: Actor> Context<A, Starting> {
             stage: PhantomData::<Running>,
         };
 
-        // Idk why anyone would do this, but we have to check that they didn't do ctx.stop()
-        // in the started method, otherwise it would kinda be a bug
-        if !runnning_context.check_running(&mut actor).await {
-            runnning_context.stop_all();
-            return actor.stopped().await;
-        }
-
         // Similar to above
         if let Some(BroadcastMessage::Shutdown) =
             runnning_context.broadcast_receiver.try_recv().unwrap()

--- a/src/context.rs
+++ b/src/context.rs
@@ -150,7 +150,9 @@ impl<A: Actor> Context<A, Starting> {
 
     /// Run the given actor's main loop, handling incoming messages to its mailbox.
     pub async fn run(mut self, mut actor: A) -> A::Stop {
-        actor.started(&mut self).await;
+        if let Err(stop) = actor.started(&mut self).await {
+            return stop;
+        }
 
         let mut runnning_context = Context::<A, Running> {
             running: self.running,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub use self::address::{Address, Disconnected, WeakAddress};
 pub use self::context::{ActorShutdown, Context};
 pub use self::manager::ActorManager;
+use crate::context::{Running, Starting};
 
 pub mod address;
 mod context;
@@ -34,6 +35,9 @@ pub mod prelude {
     pub use crate::{Actor, Handler};
 
     pub use async_trait::async_trait;
+
+    pub use crate::context::Running;
+    pub use crate::context::Starting;
 }
 
 /// A trait indicating that an [`Actor`](trait.Actor.html) can handle a given [`Message`](trait.Message.html)
@@ -98,7 +102,7 @@ pub trait Handler<M>: Actor {
 /// #[async_trait]
 /// impl Actor for MyActor {
 ///     type Stop = ();
-///     async fn started(&mut self, ctx: &mut Context<Self>) {
+///     async fn started(&mut self, ctx: &mut Context<Self, Starting>) {
 ///         println!("Started!");
 ///     }
 ///
@@ -142,7 +146,7 @@ pub trait Actor: 'static + Send + Sized {
 
     /// Called as soon as the actor has been started.
     #[allow(unused_variables)]
-    async fn started(&mut self, ctx: &mut Context<Self>) {}
+    async fn started(&mut self, ctx: &mut Context<Self, Starting>) {}
 
     /// Called when the actor calls the [`Context::stop`](struct.Context.html#method.stop). This method
     /// can prevent the actor from stopping by returning [`KeepRunning::Yes`](enum.KeepRunning.html#variant.Yes).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 pub use self::address::{Address, Disconnected, WeakAddress};
 pub use self::context::{ActorShutdown, Context};
 pub use self::manager::ActorManager;
-use crate::context::{Running, Starting};
+use crate::context::Starting;
 
 pub mod address;
 mod context;
@@ -102,8 +102,10 @@ pub trait Handler<M>: Actor {
 /// #[async_trait]
 /// impl Actor for MyActor {
 ///     type Stop = ();
-///     async fn started(&mut self, ctx: &mut Context<Self, Starting>) {
+///     async fn started(&mut self, ctx: &mut Context<Self, Starting>) -> Result<(), Self::Stop> {
 ///         println!("Started!");
+///
+///         Ok(())
 ///     }
 ///
 ///     async fn stopping(&mut self, ctx: &mut Context<Self>) -> KeepRunning {
@@ -146,7 +148,9 @@ pub trait Actor: 'static + Send + Sized {
 
     /// Called as soon as the actor has been started.
     #[allow(unused_variables)]
-    async fn started(&mut self, ctx: &mut Context<Self, Starting>) {}
+    async fn started(&mut self, ctx: &mut Context<Self, Starting>) -> Result<(), Self::Stop> {
+        Ok(())
+    }
 
     /// Called when the actor calls the [`Context::stop`](struct.Context.html#method.stop). This method
     /// can prevent the actor from stopping by returning [`KeepRunning::Yes`](enum.KeepRunning.html#variant.Yes).

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::address::Address;
-use crate::context::Context;
+use crate::context::{Context, Starting};
 use crate::envelope::{BroadcastMessageEnvelope, MessageEnvelope};
 use crate::spawn::Spawner;
 use crate::Actor;
@@ -45,7 +45,7 @@ pub(crate) enum ContinueManageLoop {
 pub struct ActorManager<A: Actor> {
     pub(crate) address: Address<A>,
     pub(crate) actor: A,
-    pub(crate) ctx: Context<A>,
+    pub(crate) ctx: Context<A, Starting>,
 }
 
 impl<A: Actor<Stop = ()>> ActorManager<A> {


### PR DESCRIPTION
Currently, we have a funny condition within `run` where actors can theoretically call `Context::stop` from within the `started` function. A code-comment currently hints that this idea is a bit silly.

By using a separate type-parameter, we can indicate the "life-cycle stage" of the actor. Through this, we can make it impossible to call `Context::stop` as part of the actor's `started` lifecycle callback.

To still allow for a fallible `started` function, we change the type-signature to return `Result<(), Self::Stop>`.

If this idea is welcome, I can polish the code a bit more. Names for life-cycle stages are subject to bike-shedding. At the moment, it is also not possible to call `handle_while` and other `Context` functions as part of `started`. This decision may need to be revisited.