### PR TITLE
Minimal 2021 edition update, MSRV -> 1.56, GHA update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         toolchain: [
           stable,
           beta,
-          1.54.0 # MSRV
+          1.56.0 # MSRV
         ]
         args: [
           --all-features,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions-rs/toolchain@1.0.7
+        with:
+          profile: minimal
+          toolchain: nightly
+
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
@@ -32,6 +37,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ matrix.args }}
+
+      - run: cargo +nightly update -Z minimal-versions
 
       - run: cargo fmt -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@1.0.7
+      - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
           toolchain: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "xtra"
 version = "0.6.0"
 description = "A tiny actor framework"
 authors = ["Restioson <restiosondev@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/Restioson/xtra"
 documentation = "https://docs.rs/xtra"
@@ -18,7 +18,7 @@ catty = "0.1.4"
 flume = { version = "0.10.9", default-features = false, features = ["async"] }
 futures-core = { version = "0.3.5", default-features = false, features = ["alloc"] }
 futures-sink = { version = "0.3.5", default-features = false }
-futures-util = { version = "0.3.5", default-features = false, features = ["sink"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["sink", "alloc"] }
 pollster = "0.2"
 event-listener = "2.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/xtra"
 readme = "README.md"
 keywords = ["async", "actor", "futures", "xtra", "async-await"]
 categories = ["asynchronous", "concurrency"]
+rust-version = "1.56.0"
 
 [dependencies]
 async-trait = "0.1.36"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ is recommended in order to enable some  convenience methods (such as `Actor::spa
 which executor you want to use (check out their docs to learn more about each). If you have any questions, feel free to
 [open an issue](https://github.com/Restioson/xtra/issues/new) or message me on the [Rust discord](https://bit.ly/rust-community).
 
+Keep in mind that `xtra` has a MSRV of 1.56.0.
+
 ## Cargo features
 
 - `timing`: enables the `notify_interval` method, and brings in the

--- a/examples/basic_wasm_bindgen/Cargo.toml
+++ b/examples/basic_wasm_bindgen/Cargo.toml
@@ -15,3 +15,4 @@ async-trait = "0.1"
 
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3.13", default-features = false }
+console_error_panic_hook = "0.1.5" # First version that works on stable


### PR DESCRIPTION
Changes xtra's MSRV to 1.56, enables edition 2021, and make actions use minimal-versions. 

## MSRV -> 1.56
This was required for edition 2021, as it was the first stable version with edition 2021 enabled. 

## Edition 2021
The main effect this had is the different feature resolver needed one feature to be added explicitly to futures-util.

## Actions
There are two reasons for making Actions use `minimal-versions`:
1. Unfortunately, since the CI is tested on 1.56 too *without* Cargo.lock being committed, the latest dependencies are always used. This includes updating to those beyond the MSRV of the root crate (xtra) - see https://github.com/rust-lang/cargo/issues/9930. This lead to some CI failures which did not reflect actual MSRV issues with xtra, since the dependencies updated beyond xtra's MSRV had releases allowed by xtra that did support xtra's MSRV.
2.Using `minimal-versions` makes sure that the versions specified in `Cargo.toml` are not incorrect - see [Rust minimum versions: SemVer is a lie!](https://blog.illicitonion.com/2018/06/rust-minimum-versions-semver-is-lie.html).

So, I decided to kill two birds with one stone and use `minimal-versions` to fix both issues.