### PR TITLE
Scoped task spawning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-core = { version = "0.3.5", default-features = false, features = ["alloc
 futures-sink = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", default-features = false, features = ["sink", "alloc"] }
 pollster = "0.2"
+pin-project-lite = "0.2.9"
 event-listener = "2.4.0"
 
 # Feature `timing`
@@ -101,6 +102,10 @@ required-features = ["with-tokio-1", "tokio/full"]
 [[example]]
 name = "send_interval"
 required-features = ["with-tokio-1", "tokio/full"]
+
+[[example]]
+name = "scoped_actor_task"
+required-features = ["with-tokio-1", "futures-util/default"]
 
 [[test]]
 name = "basic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ async-trait = "0.1.36"
 barrage = "0.2.1"
 catty = "0.1.4"
 flume = { version = "0.10.13", default-features = false, features = ["async"] }
-futures-core = { version = "0.3.5", default-features = false, features = ["alloc"] }
-futures-sink = { version = "0.3.5", default-features = false }
-futures-util = { version = "0.3.5", default-features = false, features = ["sink", "alloc"] }
+futures-core = { version = "0.3.21", default-features = false, features = ["alloc"] }
+futures-sink = { version = "0.3.21", default-features = false }
+futures-util = { version = "0.3.21", default-features = false, features = ["sink", "alloc"] }
 pollster = "0.2"
 pin-project-lite = "0.2.9"
 event-listener = "2.4.0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For better ergonomics with xtra, try the [spaad](https://crates.io/crates/spaad)
 
 ## Features
 - Safe: there is no unsafe code in xtra.
-- Tiny: xtra is less than 1k loc.
+- Tiny: xtra is less than 2kloc.
 - Lightweight: xtra has few dependencies, most of which are lightweight (except `futures`).
 - Asynchronous and synchronous message handlers.
 - Simple asynchronous message handling interface which allows `async`/`await` syntax even when borrowing `self`.

--- a/examples/scoped_actor_task.rs
+++ b/examples/scoped_actor_task.rs
@@ -44,7 +44,7 @@ async fn main() {
     };
 
     // This task will end as soon as the actor stops
-    let task = tokio::spawn(task.scoped(&addr));
+    let task = tokio::spawn(xtra::scoped(&addr, task));
 
     drop(addr);
     assert!(task.await.unwrap().is_none()); // should print "The other task has been ended."

--- a/examples/scoped_actor_task.rs
+++ b/examples/scoped_actor_task.rs
@@ -1,6 +1,5 @@
 use futures_util::future;
 use xtra::prelude::*;
-use xtra::scoped_task::ActorScopedExt;
 use xtra::spawn::Tokio;
 
 struct MyActor;

--- a/examples/scoped_actor_task.rs
+++ b/examples/scoped_actor_task.rs
@@ -1,7 +1,7 @@
-use xtra::prelude::*;
-use xtra::spawn::Tokio;
 use futures_util::future;
+use xtra::prelude::*;
 use xtra::scoped_task::ActorScopedExt;
+use xtra::spawn::Tokio;
 
 struct MyActor;
 

--- a/examples/scoped_actor_task.rs
+++ b/examples/scoped_actor_task.rs
@@ -1,0 +1,51 @@
+use xtra::prelude::*;
+use xtra::spawn::Tokio;
+use futures_util::future;
+use xtra::scoped_task::ActorScopedExt;
+
+struct MyActor;
+
+#[async_trait]
+impl Actor for MyActor {
+    type Stop = ();
+
+    async fn stopped(self) {}
+}
+
+struct Print(String);
+
+#[async_trait]
+impl Handler<Print> for MyActor {
+    type Return = ();
+
+    async fn handle(&mut self, print: Print, _ctx: &mut Context<Self>) {
+        println!("Printing {}", print.0);
+    }
+}
+
+struct DropChecker;
+
+impl Drop for DropChecker {
+    fn drop(&mut self) {
+        println!("The other task has been ended.");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let addr = MyActor.create(None).spawn(&mut Tokio::Global);
+    addr.send(Print("hello".to_string()))
+        .await
+        .expect("Actor should not be dropped");
+
+    let task = async {
+        let _checker = DropChecker;
+        future::pending::<()>().await
+    };
+
+    // This task will end as soon as the actor stops
+    let task = tokio::spawn(task.scoped(&addr));
+
+    drop(addr);
+    assert!(task.await.unwrap().is_none()); // should print "The other task has been ended."
+}

--- a/src/drop_notice.rs
+++ b/src/drop_notice.rs
@@ -41,12 +41,14 @@ pub struct DropNotice {
     listener: Option<EventListener>,
 }
 
-/// Returns a `DropNotice` that is not linked to a `DropNotifier`. Instead, it resolves
-/// immediately when polled.
-pub fn dropped() -> DropNotice {
-    DropNotice {
-        drop_event: None,
-        listener: None,
+impl DropNotice {
+    /// Returns a `DropNotice` that is not linked to a `DropNotifier`. Instead, it resolves
+    /// immediately when polled.
+    pub fn dropped() -> DropNotice {
+        DropNotice {
+            drop_event: None,
+            listener: None,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ pub mod spawn;
 #[cfg(feature = "with-tracing-0_1")]
 /// Integration with [`tracing`](https://tracing.rs).
 pub mod tracing;
+/// This module contains a way to scope a future to the lifetime of an actor, stopping it before it
+/// completes if the actor it is associated with stops too.
+pub mod scoped_task;
 
 /// Commonly used types from xtra
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,15 +20,15 @@ mod receiver;
 /// This module contains types representing the strength of an address's reference counting, which
 /// influences whether the address will keep the actor alive for as long as it lives.
 pub mod refcount;
+/// This module contains a way to scope a future to the lifetime of an actor, stopping it before it
+/// completes if the actor it is associated with stops too.
+pub mod scoped_task;
 mod send_future;
 /// This module contains a trait to spawn actors, implemented for all major async runtimes by default.
 pub mod spawn;
 #[cfg(feature = "with-tracing-0_1")]
 /// Integration with [`tracing`](https://tracing.rs).
 pub mod tracing;
-/// This module contains a way to scope a future to the lifetime of an actor, stopping it before it
-/// completes if the actor it is associated with stops too.
-pub mod scoped_task;
 
 /// Commonly used types from xtra
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ pub use self::address::{Address, Disconnected, WeakAddress};
 pub use self::context::{ActorShutdown, Context};
 pub use self::manager::ActorManager;
 pub use self::receiver::Receiver;
-pub use self::send_future::NameableSending;
-pub use self::send_future::SendFuture;
+pub use self::scoped_task::scoped;
+pub use self::send_future::{NameableSending, SendFuture};
 
 pub mod address;
 mod context;

--- a/src/refcount.rs
+++ b/src/refcount.rs
@@ -1,4 +1,4 @@
-use crate::drop_notice::{self, DropNotice};
+use crate::drop_notice::DropNotice;
 use crate::private::Sealed;
 use std::fmt::{Debug, Formatter};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -207,7 +207,7 @@ impl RefCounter for Weak {
                 drop(shared);
                 drop_notice
             }
-            None => drop_notice::dropped(),
+            None => DropNotice::dropped(),
         }
     }
 }

--- a/src/scoped_task.rs
+++ b/src/scoped_task.rs
@@ -1,0 +1,60 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use futures_util::FutureExt;
+use crate::Address;
+use crate::drop_notice::DropNotice;
+use crate::refcount::RefCounter;
+
+pin_project_lite::pin_project! {
+    /// A task that is scoped to the lifecycle of an actor. This means that when the associated
+    /// actor stops, the task will stop too. This future will either complete when the inner future
+    /// completes, or when the actor is dropped, whichever comes first. If the inner future completes
+    /// successfully, `Some(result)` will be returned, else `None` will be returned if the actor
+    /// is stopped before it could be polled to completion.
+    #[must_use = "Futures do nothing unless polled"]
+    pub struct ScopedTask<F: ?Sized> {
+        drop_notice: DropNotice,
+        #[pin]
+        fut: F,
+    }
+}
+
+impl<F> Future for ScopedTask<F>
+    where F: Future
+{
+    type Output = Option<F::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.fut.poll(cx) {
+            Poll::Ready(v) => Poll::Ready(Some(v)),
+            Poll::Pending => match this.drop_notice.poll_unpin(cx) {
+                Poll::Ready(()) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}
+
+/// Extension trait to allow a future to be conveniently converted to a [`ScopedTask`], which will
+/// end as soon as the actor is stopped, or when it completes (whichever comes first).
+pub trait ActorScopedExt {
+    /// Convert this future to a [`ScopedTask`].
+    fn scoped<A, Rc>(self, address: &Address<A, Rc>) -> ScopedTask<Self>
+        where Rc: RefCounter;
+}
+
+impl<F> ActorScopedExt for F
+    where F: Future
+{
+    fn scoped<A, Rc>(self, address: &Address<A, Rc>) -> ScopedTask<Self>
+        where Rc: RefCounter
+    {
+        ScopedTask {
+            drop_notice: address.ref_counter.disconnect_notice(),
+            fut: self,
+        }
+    }
+}

--- a/src/scoped_task.rs
+++ b/src/scoped_task.rs
@@ -45,7 +45,7 @@ where
             Poll::Pending => match this.fut.poll(cx) {
                 Poll::Ready(v) => Poll::Ready(Some(v)),
                 Poll::Pending => Poll::Pending,
-            }
+            },
         }
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,9 +1,9 @@
+use futures_util::task::noop_waker_ref;
 use futures_util::FutureExt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
-use futures_util::task::noop_waker_ref;
 
 use smol_timeout::TimeoutExt;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,7 +1,9 @@
 use futures_util::FutureExt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
+use futures_util::task::noop_waker_ref;
 
 use smol_timeout::TimeoutExt;
 
@@ -294,4 +296,40 @@ fn address_debug() {
         "Address<basic::Greeter> { \
         ref_counter: Weak { connected: true, strong_count: 2, weak_count: 2 } }"
     );
+}
+
+#[test]
+fn scoped_task() {
+    // Completes when address is connected
+    let (addr, ctx) = Context::<Greeter>::new(None);
+    let scoped = xtra::scoped(&addr, futures_util::future::ready(()));
+    assert!(scoped.now_or_never().is_some());
+
+    // Does not complete when address starts off from a disconnected weak
+    let weak = addr.downgrade();
+    drop(addr);
+    assert!(ctx.run(Greeter).now_or_never().is_some());
+    let scoped = xtra::scoped(&weak, futures_util::future::ready(()));
+    assert_eq!(scoped.now_or_never(), Some(None));
+
+    // Does not complete when address starts off from a disconnected strong
+    let (addr, ctx) = Context::<ActorReturningStopSelf>::new(None);
+    let _ = addr.send(Stop).split_receiver().now_or_never().unwrap();
+    assert!(ctx.run(ActorReturningStopSelf).now_or_never().is_some());
+    let scoped = xtra::scoped(&addr, futures_util::future::ready(()));
+    assert_eq!(scoped.now_or_never(), Some(None));
+
+    // Does not complete when address disconnects after ScopedTask creation but before first poll
+    let (addr, ctx) = Context::<Greeter>::new(None);
+    drop(ctx);
+    let scoped = xtra::scoped(&addr, futures_util::future::ready(()));
+    assert_eq!(scoped.now_or_never(), Some(None));
+
+    // Does not complete when address disconnects after ScopedTask creation but before first poll
+    let (addr, act_ctx) = Context::<Greeter>::new(None);
+    let mut scoped = xtra::scoped(&addr, futures_util::future::pending::<()>()).boxed();
+    let mut fut_ctx = std::task::Context::from_waker(noop_waker_ref());
+    assert!(scoped.poll_unpin(&mut fut_ctx).is_pending());
+    drop(act_ctx);
+    assert_eq!(scoped.poll_unpin(&mut fut_ctx), Poll::Ready(None));
 }


### PR DESCRIPTION
This is a concept for an API which allows you to spawn tasks that will never outlive the actor. It might be better suited to an extension crate at a later date.

CC @klochowicz 