### PR TITLE
Use `NonReturningEnvelope` for broadcasting

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -290,11 +290,11 @@ impl<A: Actor> Context<A> {
         M: Clone + Sync + Send + 'static,
         A: Handler<M, Return = ()>,
     {
-        let envelope = BroadcastEnvelopeConcrete::<A, M>::new(msg, 1);
+        let envelope = BroadcastEnvelopeConcrete::<A, M>::new(msg);
         self.receiver
             .sender()
             .ok_or(ActorShutdown)?
-            .broadcast(Arc::new(envelope))
+            .broadcast(Arc::new(envelope), 1)
             .map_err(|_| ActorShutdown)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::envelope::NonReturningEnvelope;
+use crate::envelope::UnitReturnEnvelope;
 use crate::inbox::{rx::RxStrong, ActorMessage};
 use crate::{inbox, Actor, Address, Handler};
 use futures_util::future::{self, Either};
@@ -289,7 +289,7 @@ impl<A: Actor> Context<A> {
         M: Clone + Sync + Send + 'static,
         A: Handler<M, Return = ()>,
     {
-        let envelope = NonReturningEnvelope::<A, M>::new(msg);
+        let envelope = UnitReturnEnvelope::<A, M>::new(msg);
         self.receiver
             .sender()
             .ok_or(ActorShutdown)?

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::envelope::BroadcastEnvelopeConcrete;
+use crate::envelope::NonReturningEnvelope;
 use crate::inbox::{rx::RxStrong, ActorMessage};
 use crate::{inbox, Actor, Address, Handler};
 use futures_util::future::{self, Either};
@@ -6,7 +6,6 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
 use std::ops::ControlFlow;
-use std::sync::Arc;
 #[cfg(feature = "timing")]
 use {futures_timer::Delay, std::time::Duration};
 
@@ -290,11 +289,11 @@ impl<A: Actor> Context<A> {
         M: Clone + Sync + Send + 'static,
         A: Handler<M, Return = ()>,
     {
-        let envelope = BroadcastEnvelopeConcrete::<A, M>::new(msg);
+        let envelope = NonReturningEnvelope::<A, M>::new(msg);
         self.receiver
             .sender()
             .ok_or(ActorShutdown)?
-            .broadcast(Arc::new(envelope), 1)
+            .broadcast(Box::new(envelope), 1)
             .map_err(|_| ActorShutdown)
     }
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -6,7 +6,6 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 
 use crate::context::Context;
-use crate::inbox::{HasPriority, Priority};
 use crate::{Actor, Handler};
 
 /// A message envelope is a struct that encapsulates a message and its return channel sender (if applicable).
@@ -124,7 +123,7 @@ pub trait BroadcastMessageEnvelope: MessageEnvelope + Sync {
 }
 
 /// Like MessageEnvelope, but with an Arc instead of Box
-pub trait BroadcastEnvelope: HasPriority + Send + Sync {
+pub trait BroadcastEnvelope: Send + Sync {
     type Actor;
 
     fn handle<'a>(
@@ -136,15 +135,13 @@ pub trait BroadcastEnvelope: HasPriority + Send + Sync {
 
 pub struct BroadcastEnvelopeConcrete<A, M> {
     message: M,
-    priority: i32,
     phantom: PhantomData<fn() -> A>,
 }
 
 impl<A: Actor, M> BroadcastEnvelopeConcrete<A, M> {
-    pub fn new(message: M, priority: i32) -> Self {
+    pub fn new(message: M) -> Self {
         BroadcastEnvelopeConcrete {
             message,
-            priority,
             phantom: PhantomData,
         }
     }
@@ -163,11 +160,5 @@ where
         ctx: &'a mut Context<Self::Actor>,
     ) -> BoxFuture<'a, ()> {
         Box::pin(act.handle(self.message.clone(), ctx))
-    }
-}
-
-impl<A, M> HasPriority for BroadcastEnvelopeConcrete<A, M> {
-    fn priority(&self) -> Priority {
-        Priority::Valued(self.priority)
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -125,11 +125,6 @@ impl<A: Handler<M>, M: Send + 'static> MessageEnvelope for NonReturningEnvelope<
     }
 }
 
-/// Like MessageEnvelope, but can be cloned.
-pub trait BroadcastMessageEnvelope: MessageEnvelope + Sync {
-    fn clone(&self) -> Box<dyn BroadcastMessageEnvelope<Actor = Self::Actor>>;
-}
-
 /// Like MessageEnvelope, but with an Arc instead of Box
 pub trait BroadcastEnvelope: MessageEnvelope + Send + Sync {
     fn clone(&self) -> Box<dyn BroadcastEnvelope<Actor = Self::Actor>>;

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -252,7 +252,7 @@ impl<A> Ord for Prioritized<A> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::envelope::NonReturningEnvelope;
+    use crate::envelope::UnitReturnEnvelope;
     use crate::prelude::{Context, *};
     use futures_util::FutureExt;
 
@@ -285,7 +285,7 @@ mod test {
         let (tx, rx) = new(None);
         let rx2 = rx.shallow_weak_clone();
 
-        let orig = Box::new(NonReturningEnvelope::new("Hi"));
+        let orig = Box::new(UnitReturnEnvelope::new("Hi"));
         let orig = orig as Box<dyn BroadcastEnvelope<Actor = MyActor>>;
         tx.broadcast(orig.clone(), 1).unwrap();
 

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -87,7 +87,7 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
                 Ok(inner.pop_priority().unwrap().into())
             }
             // Shared priority is less - take from broadcast
-            Ordering::Less => Ok(broadcast.pop().unwrap().0.into()),
+            Ordering::Less => Ok(broadcast.pop().unwrap().into()),
             // Equal, but both are empty, so wait or exit if shutdown
             _ => {
                 // Shutdown is only edited when inner is locked, and we have it locked now, so no
@@ -107,7 +107,7 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
         self.broadcast_mailbox
             .lock()
             .pop()
-            .map(|msg| ActorMessage::ToAllActors(msg.0))
+            .map(|msg| ActorMessage::ToAllActors(msg.message))
     }
 }
 

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -220,7 +220,7 @@ impl<A, Rc: RxRefCounter> Drop for ReceiveFuture<A, Rc> {
                     Err(WakeReason::MessageToOneActor(msg)) => {
                         if msg.priority == Priority::default() {
                             // Preserve ordering as much as possible by pushing to the front
-                            inner.ordered_queue.push_front(msg.val)
+                            inner.ordered_queue.push_front(msg.message)
                         } else {
                             inner.priority_queue.push(msg);
                         }

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -94,7 +94,7 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
 
     pub fn broadcast(
         &self,
-        message: Arc<dyn BroadcastEnvelope<Actor = A>>,
+        message: Box<dyn BroadcastEnvelope<Actor = A>>,
         priority: i32,
     ) -> Result<(), Disconnected> {
         let message = Prioritized::new(Priority::Valued(priority), message);


### PR DESCRIPTION
This fell out of playing around with `Box` vs `Arc` for broadcasting when I realized that we don't actually need an `Arc` if we special case the trait anyway because we can just clone the entire envelope.

Let me know what you think!