### PR TITLE
Make split_receiver() resolve to Result<Receiver>

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -47,7 +47,7 @@ fn throughput(c: &mut Criterion) {
             |b, &num_messages| {
                 b.to_async(&runtime).iter(|| async {
                     for _ in 0..num_messages - 1 {
-                        let _ = address.send(IncrementZst).split_receiver().await;
+                        let _ = address.send(IncrementZst).split_receiver().await.unwrap();
                     }
 
                     address.send(IncrementZst).await.unwrap()

--- a/examples/backpressure.rs
+++ b/examples/backpressure.rs
@@ -68,6 +68,6 @@ async fn main() {
         let name = "world!".to_owned();
 
         println!("Greeting {}", name);
-        let _ = address.send(Hello(name)).split_receiver().await;
+        let _ = address.send(Hello(name)).split_receiver().await.unwrap();
     }
 }

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::time::{Duration, Instant};
 
-use futures_util::FutureExt;
 use xtra::prelude::*;
 use xtra::spawn::Tokio;
 use xtra::SendFuture;
@@ -107,7 +106,7 @@ async fn do_address_benchmark<R>(
 
     // rounding overflow
     for _ in 0..COUNT {
-        let _ = f(&addr).now_or_never();
+        let _ = f(&addr).await;
     }
 
     // awaiting on GetCount will make sure all previous messages are processed first BUT introduces

--- a/src/context.rs
+++ b/src/context.rs
@@ -165,7 +165,7 @@ impl<A: Actor> Context<A> {
     ///     async fn handle(&mut self, _msg: Joining, ctx: &mut Context<Self>) -> bool {
     ///         let addr = ctx.address().unwrap();
     ///         let join = ctx.join(self, future::ready::<()>(()));
-    ///         let _ = addr.send(Stop).split_receiver().await;
+    ///         let _ = addr.send(Stop).split_receiver().await.unwrap();
     ///
     ///         // Actor is stopping, but the join should still evaluate correctly
     ///         join.now_or_never().is_some()
@@ -233,7 +233,7 @@ impl<A: Actor> Context<A> {
     ///
     ///         let addr = ctx.address().unwrap();
     ///         let select = ctx.select(self, future::pending::<()>());
-    ///         let _ = addr.send(Stop).split_receiver().await;
+    ///         let _ = addr.send(Stop).split_receiver().await.unwrap();
     ///
     ///         // Actor is stopping, so this will return Err, even though the future will
     ///         // usually never complete.


### PR DESCRIPTION
This change lets users figure out from `split_receiver()` futures awaited once whether the message was actually delivered or not. There are maybe other ways to accomplish this from an API perspective, though.