### PR TITLE
Remove the 'static bound on A of Address

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -2,11 +2,8 @@
 
 ## 0.6.0
 
-- Sealed `RefCounter`, `MessageChannel`, and `MessageSink` traits
-- `AddressSink` no longer exists - `Address` now implements `Sink` directly for any handlers returning `()`.
+- Sealed `RefCounter` and `MessageChannel` traits
 - `Message` no longer exists - `Return` is now specified on the `Handler` trait itself.
-- `Address` is no longer `Sync`, due to it implementing `AddressSink`. You should just be able to clone it and then send
-  it, though.
 - `Context::notify_interval` and `Context::notify_after` are now subject to back-pressure, in case the address mailbox
   is full. These aren't API breaking but a semantic changes.
 - `stopping` has been removed in favour of `stop_self` and `stop_all`. If logic to determine if the actor should stop
@@ -16,6 +13,7 @@
   `stop_all` in line with `stop_self`.
 - `MessageChannel` is now a `struct` that can be constructed from an `Address` via `MessageChannel::new` or using
   `From`/`Into`.
+- `AddressSink` was removed in favor of using `impl Trait` for the `Address::into_sink` method.
 
 ## 0.5.0
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -10,11 +10,11 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use event_listener::EventListener;
-use futures_core::{FusedFuture, Stream};
+use futures_core::Stream;
 use futures_sink::Sink;
 use futures_util::{future, FutureExt, StreamExt};
 
-use crate::envelope::{NonReturningEnvelope, ReturningEnvelope};
+use crate::envelope::ReturningEnvelope;
 use crate::inbox::{PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::ResolveToHandlerReturn;
@@ -252,8 +252,12 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
 
     /// Converts this address into a sink that can be used to send messages to the actor. These
     /// messages will have default priority and be handled in send order.
-    pub fn into_sink(self) -> AddressSink<A, Rc> {
-        AddressSink(inbox::SendFuture::empty(self.0))
+    pub fn into_sink<M>(self) -> impl Sink<M, Error = Disconnected>
+    where
+        A: Handler<M, Return = ()>,
+        M: Send + 'static,
+    {
+        futures_util::sink::unfold((), move |(), message| self.send(message))
     }
 }
 
@@ -323,49 +327,5 @@ impl<A, Rc: RefCounter> Hash for Address<A, Rc> {
         state.write_usize(self.0.inner_ptr() as *const _ as usize);
         state.write_u8(self.0.is_strong() as u8);
         state.finish();
-    }
-}
-
-/// A sink which can be used to send messages to an actor. These messages will have default priority
-/// and be handled in send order.
-pub struct AddressSink<A, Rc: RefCounter>(inbox::SendFuture<A, Rc>);
-
-impl<A, Rc: RefCounter> AddressSink<A, Rc> {
-    /// Return a clone of the underlying [`Address`] which this sink sends to.
-    pub fn address(&self) -> Address<A, Rc> {
-        Address(self.0.tx.clone())
-    }
-}
-
-impl<A, M, Rc: RefCounter> Sink<M> for AddressSink<A, Rc>
-where
-    A: Handler<M, Return = ()>,
-    M: Send + 'static,
-{
-    type Error = Disconnected;
-
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if let Poll::Ready(Err(Disconnected)) = self.0.poll_unpin(cx) {
-            Poll::Ready(Err(Disconnected))
-        } else if self.0.is_terminated() {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
-        }
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, msg: M) -> Result<(), Self::Error> {
-        let msg = Box::new(NonReturningEnvelope::new(msg));
-        let msg = SentMessage::ToOneActor(PriorityMessageToOne::new(0, msg));
-        self.0 = self.0.tx.send(msg);
-        Ok(())
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.poll_ready(cx)
-    }
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.poll_flush(cx)
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -78,7 +78,7 @@ impl Error for Disconnected {}
 /// of their priority. All actors must handle a message for it to be removed from the mailbox and
 /// the length to decrease. This means that the backpressure provided by [`Address::broadcast`] will
 /// wait for the slowest actor.
-pub struct Address<A: 'static, Rc: RefCounter = Strong>(pub(crate) inbox::Sender<A, Rc>);
+pub struct Address<A, Rc: RefCounter = Strong>(pub(crate) inbox::Sender<A, Rc>);
 
 impl<A, Rc: RefCounter> Debug for Address<A, Rc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -52,7 +52,7 @@ pub trait MessageEnvelope: Send {
 pub struct ReturningEnvelope<A, M, R> {
     message: M,
     result_sender: Sender<R>,
-    phantom: PhantomData<fn() -> A>,
+    phantom: PhantomData<for<'a> fn(&'a A)>,
 }
 
 impl<A: Actor, M, R: Send + 'static> ReturningEnvelope<A, M, R> {
@@ -68,8 +68,10 @@ impl<A: Actor, M, R: Send + 'static> ReturningEnvelope<A, M, R> {
     }
 }
 
-impl<A: Handler<M, Return = R>, M: Send + 'static, R: Send + 'static> MessageEnvelope
-    for ReturningEnvelope<A, M, R>
+impl<A, M, R> MessageEnvelope for ReturningEnvelope<A, M, R>
+    where A: Handler<M, Return = R>,
+          M: Send + 'static,
+          R: Send + 'static
 {
     type Actor = A;
 
@@ -106,7 +108,10 @@ impl<A: Actor, M> NonReturningEnvelope<A, M> {
     }
 }
 
-impl<A: Handler<M>, M: Send + 'static> MessageEnvelope for NonReturningEnvelope<A, M> {
+impl<A, M> MessageEnvelope for NonReturningEnvelope<A, M>
+    where A: Handler<M>,
+          M: Send + 'static
+{
     type Actor = A;
 
     fn handle<'a>(
@@ -145,7 +150,7 @@ impl<A, M> BroadcastEnvelopeConcrete<A, M> {
     }
 }
 
-impl<A: Handler<M>, M> BroadcastEnvelope for BroadcastEnvelopeConcrete<A, M>
+impl<A, M> BroadcastEnvelope for BroadcastEnvelopeConcrete<A, M>
 where
     A: Handler<M, Return = ()>,
     M: Clone + Send + Sync + 'static,

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -69,9 +69,10 @@ impl<A: Actor, M, R: Send + 'static> ReturningEnvelope<A, M, R> {
 }
 
 impl<A, M, R> MessageEnvelope for ReturningEnvelope<A, M, R>
-    where A: Handler<M, Return = R>,
-          M: Send + 'static,
-          R: Send + 'static
+where
+    A: Handler<M, Return = R>,
+    M: Send + 'static,
+    R: Send + 'static,
 {
     type Actor = A;
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -92,37 +92,6 @@ impl<A, M, R> MessageEnvelope for ReturningEnvelope<A, M, R>
     }
 }
 
-/// An envelope that does not return a result from a message. Constructed  by the `AddressExt::do_send`
-/// method.
-pub struct NonReturningEnvelope<A, M> {
-    message: M,
-    phantom: PhantomData<fn() -> A>,
-}
-
-impl<A: Actor, M> NonReturningEnvelope<A, M> {
-    pub fn new(message: M) -> Self {
-        NonReturningEnvelope {
-            message,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<A, M> MessageEnvelope for NonReturningEnvelope<A, M>
-    where A: Handler<M>,
-          M: Send + 'static
-{
-    type Actor = A;
-
-    fn handle<'a>(
-        self: Box<Self>,
-        act: &'a mut Self::Actor,
-        ctx: &'a mut Context<Self::Actor>,
-    ) -> BoxFuture<'a, ()> {
-        Box::pin(act.handle(self.message, ctx).map(|_| ()))
-    }
-}
-
 /// Like MessageEnvelope, but with an Arc instead of Box
 pub trait BroadcastEnvelope: HasPriority + Send + Sync {
     type Actor;

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -177,13 +177,6 @@ impl<A, Rc: TxRefCounter> SendFuture<A, Rc> {
             inner: SendFutureInner::New(msg),
         }
     }
-
-    pub fn empty(tx: Sender<A, Rc>) -> Self {
-        SendFuture {
-            tx,
-            inner: SendFutureInner::Complete,
-        }
-    }
 }
 
 impl<A, Rc: TxRefCounter> SetPriority for SendFuture<A, Rc> {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -5,7 +5,7 @@ use std::task::Poll;
 use std::time::Duration;
 
 use futures_util::task::noop_waker_ref;
-use futures_util::{FutureExt, SinkExt};
+use futures_util::FutureExt;
 use smol::stream;
 use smol_timeout::TimeoutExt;
 use xtra::prelude::*;
@@ -93,6 +93,7 @@ impl Actor for DropTester {
 }
 
 struct StopAll;
+
 struct StopSelf;
 
 #[async_trait]
@@ -558,7 +559,7 @@ async fn set_priority_msg_channel() {
         vec![
             Message::Priority { priority: 2 },
             Message::Priority { priority: 1 },
-            Message::Ordered { ord: 0 }
+            Message::Ordered { ord: 0 },
         ]
     );
 }
@@ -752,18 +753,6 @@ async fn address_send_exercises_backpressure() {
         .expect("be able to queue another message because the mailbox is empty again");
 
     context.yield_once(&mut Greeter).await; // process one message
-
-    // Sink
-    let mut sink = address.into_sink();
-    let _ = sink
-        .send(PrintHello("world"))
-        .now_or_never()
-        .expect("be able to queue another message because the mailbox is empty again");
-
-    assert!(
-        sink.send(PrintHello("world")).now_or_never().is_none(),
-        "Fail to queue 2nd message because mailbox is full"
-    );
 
     // Priority send
 


### PR DESCRIPTION
This removes the `'static` bound on `A` of `Address`. It also moves some inline bounds into `where` clauses, and changes the `PhantomData` to better reflect how `A` it is actually related to the envelope types.