### PR TITLE
Add TickFuture and TickFuture::get_or_create

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -494,7 +494,7 @@ impl<'a, A> Future for TickFuture<'a, A> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         match mem::replace(&mut self.state, TickState::Done) {
             TickState::Running { mut fut, phantom } => {
-                match self.span.0.in_scope(|| fut.poll_unpin(cx)) {
+                match self.span.in_scope(|| fut.poll_unpin(cx)) {
                     Poll::Ready(flow) => Poll::Ready(flow),
                     Poll::Pending => {
                         self.state = TickState::Running { fut, phantom };

--- a/src/context.rs
+++ b/src/context.rs
@@ -414,7 +414,6 @@ pub struct TickFuture<'a, A> {
     span: HandlerSpan,
 }
 
-#[cfg(feature = "instrumentation")]
 impl<'a, A> TickFuture<'a, A> {
     /// Return the handler's [`tracing::Span`](https://docs.rs/tracing/latest/tracing/struct.Span.html),
     /// creating it if it has not already been created. This can be used to log messages into the

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,4 @@
+use core::panicking::panic;
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::pin::Pin;
@@ -415,6 +416,10 @@ impl<'a, A> TickFuture<'a, A> {
     /// and the future, if the message is not a shut down. This can be used to log messages into the
     /// span when required, such as if it is cancelled later due to a timeout.
     ///
+    /// Note that this will cause the span to be created, so the returned future should be evaluated
+    /// as soon as possible after this is called, otherwise the span may be inaccurate, in that
+    /// it would start much before the handler future actually runs.
+    ///
     /// ```rust
     /// # use std::ops::ControlFlow;
     /// # use std::time::Duration;
@@ -529,7 +534,7 @@ impl<'a, A> Future for TickFuture<'a, A> {
                     Poll::Pending
                 }
             },
-            TickState::Done => Poll::Pending,
+            TickState::Done => panic!("Polled after completion"),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -138,7 +138,7 @@ impl<A: Actor> Context<A> {
             ActorMessage::Shutdown => {
                 self.running = false;
                 ControlFlow::Break(())
-            },
+            }
         }
     }
 
@@ -154,20 +154,23 @@ impl<A: Actor> Context<A> {
         &'a mut self,
         msg: Message<A>,
         actor: &'a mut A,
-    ) -> (Option<tracing::Span>, impl Future<Output = ControlFlow<()>> + 'a) {
+    ) -> (
+        Option<tracing::Span>,
+        impl Future<Output = ControlFlow<()>> + 'a,
+    ) {
         match msg.0 {
             ActorMessage::ToOneActor(msg) => {
                 let (fut, span) = msg.handle(actor, self);
                 (Some(span.0), Either::Left(fut))
-            },
+            }
             ActorMessage::ToAllActors(msg) => {
                 let (fut, span) = msg.handle(actor, self);
                 (Some(span.0), Either::Left(fut))
-            },
+            }
             ActorMessage::Shutdown => {
                 self.running = false;
                 (None, Either::Right(future::ready(ControlFlow::Break(()))))
-            },
+            }
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -455,10 +455,11 @@ impl<'a, A> TickFuture<'a, A> {
     pub fn get_or_create_span(&mut self) -> &tracing::Span {
         let span = mem::replace(&mut self.span.0, tracing::Span::none());
         *self = match mem::replace(&mut self.state, TickState::Done) {
-            TickState::New { msg, act, ctx } => {
-                TickFuture::running(msg, act, ctx)
-            }
-            state => TickFuture { state, span: HandlerSpan(span) },
+            TickState::New { msg, act, ctx } => TickFuture::running(msg, act, ctx),
+            state => TickFuture {
+                state,
+                span: HandlerSpan(span),
+            },
         };
 
         &self.span.0
@@ -476,7 +477,7 @@ impl<'a, A> TickFuture<'a, A> {
                 fut,
                 phantom: PhantomData,
             },
-            span
+            span,
         }
     }
 }
@@ -497,12 +498,11 @@ enum TickState<'a, A> {
 impl<'a, A> TickFuture<'a, A> {
     fn new(msg: ActorMessage<A>, act: &'a mut A, ctx: &'a mut Context<A>) -> Self {
         TickFuture {
-            state: TickState::New {
-                msg,
-                act,
-                ctx,
-            },
-            span: HandlerSpan(#[cfg(feature = "instrumentation")] tracing::Span::none())
+            state: TickState::New { msg, act, ctx },
+            span: HandlerSpan(
+                #[cfg(feature = "instrumentation")]
+                tracing::Span::none(),
+            ),
         }
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -62,14 +62,24 @@ struct Instrumentation {
 pub struct HandlerSpan(#[cfg(feature = "instrumentation")] pub tracing::Span);
 
 impl HandlerSpan {
-    #[cfg(feature = "instrumentation")]
-    fn disabled() -> HandlerSpan {
-        HandlerSpan(tracing::Span::none())
+    pub fn in_scope<R>(&self, f: impl FnOnce() -> R) -> R {
+        #[cfg(feature = "instrumentation")]
+        let r = self.0.in_scope(f);
+
+        #[cfg(not(feature = "instrumentation"))]
+        let r = f();
+
+        r
     }
 
-    #[cfg(not(feature = "instrumentation"))]
     fn disabled() -> HandlerSpan {
-        HandlerSpan()
+        #[cfg(feature = "instrumentation")]
+        let span = HandlerSpan(tracing::Span::none());
+
+        #[cfg(not(feature = "instrumentation"))]
+        let span = HandlerSpan();
+
+        span
     }
 }
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -109,7 +109,7 @@ impl Instrumentation {
         }
 
         #[cfg(not(feature = "instrumentation"))]
-        (HandlerSpan(), fut)
+        (fut, HandlerSpan())
     }
 }
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -58,6 +58,7 @@ struct Instrumentation {
     _waiting_for_actor: tracing::Span,
 }
 
+#[derive(Clone)]
 pub struct HandlerSpan(#[cfg(feature = "instrumentation")] pub tracing::Span);
 
 impl Instrumentation {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -104,7 +104,7 @@ impl Instrumentation {
 
             (
                 tracing::Instrument::instrument(fut, executing.clone()),
-                HandlerSpan(executing)
+                HandlerSpan(executing),
             )
         }
 
@@ -155,9 +155,7 @@ where
             ..
         } = *self;
 
-        let fut = async move {
-            (act.handle(message, ctx).await, ctx.flow())
-        };
+        let fut = async move { (act.handle(message, ctx).await, ctx.flow()) };
 
         let (fut, span) = instrumentation.apply::<A, M, _>(fut);
 
@@ -179,7 +177,7 @@ pub trait BroadcastEnvelope: HasPriority + Send + Sync {
         self: Arc<Self>,
         act: &'a mut Self::Actor,
         ctx: &'a mut Context<Self::Actor>,
-    ) ->  (BoxFuture<'a, ControlFlow<()>>, HandlerSpan);
+    ) -> (BoxFuture<'a, ControlFlow<()>>, HandlerSpan);
 }
 
 pub struct BroadcastEnvelopeConcrete<A, M> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -10,7 +10,7 @@ use futures_core::FusedFuture;
 use futures_util::FutureExt;
 
 use super::*;
-use crate::envelope::ShutdownAll;
+use crate::envelope::Shutdown;
 use crate::inbox::tx::private::RefCounterInner;
 use crate::send_future::private::SetPriority;
 use crate::{Actor, Error};
@@ -83,7 +83,7 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
             .chan
             .lock()
             .unwrap()
-            .send_broadcast(MessageToAllActors(Arc::new(ShutdownAll::new())));
+            .send_broadcast(MessageToAllActors(Arc::new(Shutdown::new())));
     }
 
     pub fn send(&self, message: SentMessage<A>) -> SendFuture<A, Rc> {


### PR DESCRIPTION
This PR adds a function which returns the span of the inner message handler, so that it can be recorded and logged to by a custom event loop.

## Motivating example

```rust
pub async fn run(mut self, mut actor: A) -> A::Stop {
    loop {
        let msg = self.ctx.next_message().await;

        let (span, fut) = self.ctx.tick_instrumented(msg, &mut actor);
        match timeout(self.timeout, fut).await {
            Ok(ControlFlow::Continue(())) => (),
            Ok(ControlFlow::Break(())) => break actor.stopped().await,
            Err(_elapsed) => {
                if let Some(span) = span {
                    let _entered = span.enter();
                    let timeout_seconds = self.timeout.as_secs();
                    span.record("interrupted", &"timed_out");
                    tracing::warn!(%timeout_seconds, "Handler execution timed out");
                }
            }
        }
    }
}
```

Without this change, there would be no way to log that the message handler timed out to any child span of `xtra_actor_request`.