### PR TITLE
Move `Context::stop_all` to `Address::stop_all`

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -17,9 +17,10 @@
 - `Context::attach_stream` was removed in favor of composing `Stream::forward` and `Address::into_sink`.
 - `KeepRunning` was removed as `Context::attach_stream` was its last usage.
 - `InstrumentedExt` was removed. All messages are now instrumented automatically when `instrumentation` is enabled.
-- `stop_all` now does not drain all messages when called, and acts just like `stop_self` on all active actors.
 - `Context::attach` is removed in favor of implementing `Clone` for `Context`. If you want to run multiple actors on a
   `Context`, simply clone it before calling `run`.
+- Introduce `Address::stop_all` as a convenience function for stopping all actors on an `Address`.
+  This is semantically equivalent to broadcasting a custom `Stop` message.
 
 ## 0.5.0
 

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -8,9 +8,6 @@
   is full. These aren't API breaking but a semantic changes.
 - `stopping` has been removed in favour of `stop_self` and `stop_all`. If logic to determine if the actor should stop
   must be executed, it should be done rather at the point of calling `stop_{self,all}`.
-- Previously, `stop_all` would immediately disconnect the address. However, `stop_self` done on every actor would actually
-  not do this in one case - if there were a free-floating (not executing an actor event loop) Context. This change brings
-  `stop_all` in line with `stop_self`.
 - `MessageChannel` is now a `struct` that can be constructed from an `Address` via `MessageChannel::new` or using
   `From`/`Into`.
 - `AddressSink` was removed in favor of using `impl Trait` for the `Address::into_sink` method.

--- a/examples/message_stealing_multiple_actors.rs
+++ b/examples/message_stealing_multiple_actors.rs
@@ -43,7 +43,7 @@ impl Handler<Print> for Printer {
 
         if self.times == 10 {
             println!("Actor {} stopping!", self.id);
-            ctx.stop_all();
+            ctx.weak_address().stop_all();
         }
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -153,7 +153,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
 
     /// Stop all actors on this [`Address`].
     ///
-    /// This is a convenience method over broadcasting a [`Stop`] message to each actor.
+    /// This is a convenience method over broadcasting a `Stop` message to each actor.
     pub fn stop_all(&self)
     where
         A: Actor,

--- a/src/context.rs
+++ b/src/context.rs
@@ -25,8 +25,7 @@ use crate::{inbox, Actor, Address, Error, WeakAddress};
 pub struct Context<A> {
     /// Whether this actor is running. If set to `false`, [`Context::tick`] will return
     /// `ControlFlow::Break` and [`Context::run`] will shut down the actor. This will not result
-    /// in other actors on the same address stopping, though - [`Context::stop_all`] must be used
-    /// to achieve this.
+    /// in other actors on the same address stopping.
     pub running: bool,
     /// The actor's mailbox.
     mailbox: inbox::Receiver<A, RxStrong>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,16 +79,6 @@ impl<A: Actor> Context<A> {
         self.running = false;
     }
 
-    /// Stop all actors on this address.
-    ///
-    /// This is equivalent to calling [`Context::stop_self`] on all actors active on this address.
-    pub fn stop_all(&mut self) {
-        // We only need to shut down if there are still any strong senders left
-        if let Some(sender) = self.mailbox.sender() {
-            sender.stop_all_receivers();
-        }
-    }
-
     /// Get an address to the current actor if there are still external addresses to the actor.
     pub fn address(&self) -> Result<Address<A>, Error> {
         self.mailbox

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub trait Handler<M>: Actor {
 ///
 ///     async fn handle(&mut self, _: Goodbye, ctx: &mut Context<Self>) {
 ///         println!("Goodbye!");
-///         ctx.stop_all();
+///         ctx.weak_address().stop_all();
 ///     }
 /// }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub trait Actor: 'static + Send + Sized {
     /// An actor's event loop can stop for several reasons:
     ///
     /// - The actor called [`Context::stop_self`].
-    /// - An actor called [`Context::stop_all`].
+    /// - Someone called [`Address::stop_all`].
     /// - The last [`Address`] with a [`Strong`](crate::refcount::Strong) reference count was dropped.
     async fn stopped(self) -> Self::Stop;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -51,7 +51,7 @@ impl Handler<StopAll> for Accumulator {
     type Return = ();
 
     async fn handle(&mut self, _: StopAll, ctx: &mut Context<Self>) -> Self::Return {
-        ctx.stop_all();
+        ctx.weak_address().stop_all();
     }
 }
 
@@ -110,7 +110,7 @@ impl Handler<StopAll> for DropTester {
     type Return = ();
 
     async fn handle(&mut self, _: StopAll, ctx: &mut Context<Self>) {
-        ctx.stop_all();
+        ctx.weak_address().stop_all();
     }
 }
 
@@ -989,7 +989,7 @@ impl Actor for InstantShutdownAll {
 
     async fn started(&mut self, ctx: &mut Context<Self>) {
         if self.stop_all {
-            ctx.stop_all();
+            ctx.weak_address().stop_all();
         }
     }
 


### PR DESCRIPTION
Stopping all actors is equivalent to sending a `Stop` message to
each actor. Sending messages is done on an `Address`. Thus stopping
all actors should be done on an `Address` too.