### PR TITLE
Move channel logic into `Chan`

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -12,8 +12,6 @@ use event_listener::EventListener;
 use futures_sink::Sink;
 use futures_util::FutureExt;
 
-use crate::envelope::ReturningEnvelope;
-use crate::inbox::{tx, PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::ResolveToHandlerReturn;
 use crate::{inbox, BroadcastFuture, Error, Handler, NameableSending, SendFuture};
@@ -171,10 +169,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
         M: Send + 'static,
         A: Handler<M>,
     {
-        let (envelope, rx) = ReturningEnvelope::<A, M, <A as Handler<M>>::Return>::new(message);
-        let msg = SentMessage::ToOneActor(PriorityMessageToOne::new(0, Box::new(envelope)));
-        let tx = tx::SendFuture::new(msg, self.0.clone());
-        SendFuture::sending_named(tx, rx)
+        SendFuture::sending_named(message, self.0.clone())
     }
 
     /// Send a message to all actors on this address.

--- a/src/address.rs
+++ b/src/address.rs
@@ -13,7 +13,7 @@ use futures_sink::Sink;
 use futures_util::FutureExt;
 
 use crate::envelope::ReturningEnvelope;
-use crate::inbox::{PriorityMessageToOne, SentMessage};
+use crate::inbox::{tx, PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::ResolveToHandlerReturn;
 use crate::{inbox, BroadcastFuture, Error, Handler, NameableSending, SendFuture};
@@ -173,7 +173,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     {
         let (envelope, rx) = ReturningEnvelope::<A, M, <A as Handler<M>>::Return>::new(message);
         let msg = SentMessage::ToOneActor(PriorityMessageToOne::new(0, Box::new(envelope)));
-        let tx = self.0.send(msg);
+        let tx = tx::SendFuture::new(msg, self.0.clone());
         SendFuture::sending_named(tx, rx)
     }
 

--- a/src/broadcast_future.rs
+++ b/src/broadcast_future.rs
@@ -89,10 +89,10 @@ where
             } => {
                 let envelope =
                     BroadcastEnvelopeConcrete::<A, M>::new(message, priority.unwrap_or(0));
-                this.inner = Inner::Sending(SendFuture::new(
-                    SentMessage::ToAllActors(Arc::new(envelope)),
-                    sender.clone(),
-                ));
+                this.inner = Inner::Sending(SendFuture::New {
+                    msg: SentMessage::ToAllActors(Arc::new(envelope)),
+                    tx: sender,
+                });
                 this.poll_unpin(cx)
             }
             Inner::Sending(mut send_fut) => match send_fut.poll_unpin(cx) {

--- a/src/broadcast_future.rs
+++ b/src/broadcast_future.rs
@@ -89,8 +89,10 @@ where
             } => {
                 let envelope =
                     BroadcastEnvelopeConcrete::<A, M>::new(message, priority.unwrap_or(0));
-                this.inner =
-                    Inner::Sending(sender.send(SentMessage::ToAllActors(Arc::new(envelope))));
+                this.inner = Inner::Sending(SendFuture::new(
+                    SentMessage::ToAllActors(Arc::new(envelope)),
+                    sender.clone(),
+                ));
                 this.poll_unpin(cx)
             }
             Inner::Sending(mut send_fut) => match send_fut.poll_unpin(cx) {

--- a/src/broadcast_future.rs
+++ b/src/broadcast_future.rs
@@ -89,10 +89,8 @@ where
             } => {
                 let envelope =
                     BroadcastEnvelopeConcrete::<A, M>::new(message, priority.unwrap_or(0));
-                this.inner = Inner::Sending(SendFuture::New {
-                    msg: SentMessage::ToAllActors(Arc::new(envelope)),
-                    tx: sender,
-                });
+                this.inner =
+                    Inner::Sending(sender.send(SentMessage::ToAllActors(Arc::new(envelope))));
                 this.poll_unpin(cx)
             }
             Inner::Sending(mut send_fut) => match send_fut.poll_unpin(cx) {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -58,6 +58,10 @@ pub struct Chan<A> {
 
 impl<A> Chan<A> {
     fn try_send(&self, message: SentMessage<A>) -> Result<(), TrySendFail<A>> {
+        if !self.is_connected() {
+            return Err(TrySendFail::Disconnected);
+        }
+
         let mut inner = self.chan.lock().unwrap();
 
         match message {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -62,6 +62,17 @@ impl<A> Chan<A> {
         }
     }
 
+    fn new_broadcast_mailbox(&self) -> Arc<BroadcastQueue<A>> {
+        let mailbox = Arc::new(Spinlock::new(BinaryHeap::new()));
+        self.chan
+            .lock()
+            .unwrap()
+            .broadcast_queues
+            .push(Arc::downgrade(&mailbox));
+
+        mailbox
+    }
+
     fn try_send(&self, message: SentMessage<A>) -> Result<(), TrySendFail<A>> {
         if !self.is_connected() {
             return Err(TrySendFail::Disconnected);

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -7,7 +7,7 @@ pub mod tx;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, VecDeque};
 use std::sync::atomic::AtomicUsize;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{atomic, Arc, Mutex, Weak};
 use std::{cmp, mem};
 
 use event_listener::Event;
@@ -96,6 +96,11 @@ impl<A> Chan<A> {
                 }
             }
         }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.receiver_count.load(atomic::Ordering::SeqCst) > 0
+            && self.sender_count.load(atomic::Ordering::SeqCst) > 0
     }
 
     fn is_full(&self, len: usize) -> bool {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -182,7 +182,7 @@ impl<A> ChanInner<A> {
             };
 
             if let Some(tx) = self.waiting_senders.remove(pos).unwrap().upgrade() {
-                return Some(tx.lock().fulfill(true));
+                return Some(tx.lock().fulfill_as_delivered());
             }
         }
     }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -103,6 +103,11 @@ impl<A> Chan<A> {
             && self.sender_count.load(atomic::Ordering::SeqCst) > 0
     }
 
+    fn len(&self) -> usize {
+        let inner = self.chan.lock().unwrap();
+        inner.broadcast_tail + inner.ordered_queue.len() + inner.priority_queue.len()
+    }
+
     fn is_full(&self, len: usize) -> bool {
         self.capacity.map_or(false, |cap| len >= cap)
     }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -390,7 +390,7 @@ impl<A> From<Arc<dyn BroadcastEnvelope<Actor = A>>> for ActorMessage<A> {
     }
 }
 
-enum WakeReason<A> {
+pub enum WakeReason<A> {
     MessageToOneActor(PriorityMessageToOne<A>),
     // should be fetched from own receiver
     MessageToAllActors,

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -243,6 +243,23 @@ impl<A> Chan<A> {
             None
         }
     }
+
+    fn pop_broadcast_message(
+        &self,
+        broadcast_mailbox: &BroadcastQueue<A>,
+    ) -> Option<MessageToAllActors<A>> {
+        let message = broadcast_mailbox.lock().pop();
+
+        // Advance the broadcast tail if we successfully took a message.
+        if message.is_some() {
+            self.chan
+                .lock()
+                .unwrap()
+                .try_advance_broadcast_tail(self.capacity);
+        }
+
+        message
+    }
 }
 
 struct ChanInner<A> {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -46,8 +46,8 @@ pub struct Chan<A> {
 impl<A> Chan<A> {
     fn new(capacity: Option<usize>) -> Self {
         Self {
-            chan: Mutex::new(ChanInner::default()),
             capacity,
+            chan: Mutex::new(ChanInner::default()),
             on_shutdown: Event::new(),
             sender_count: AtomicUsize::new(0),
             receiver_count: AtomicUsize::new(0),

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -57,6 +57,47 @@ pub struct Chan<A> {
 }
 
 impl<A> Chan<A> {
+    fn try_send(&self, message: SentMessage<A>) -> Result<(), TrySendFail<A>> {
+        let mut inner = self.chan.lock().unwrap();
+
+        match message {
+            SentMessage::ToAllActors(m) if !self.is_full(inner.broadcast_tail) => {
+                inner.send_broadcast(MessageToAllActors(m));
+                Ok(())
+            }
+            SentMessage::ToAllActors(m) => {
+                // on_shutdown is only notified with inner locked, and it's locked here, so no race
+                let waiting = WaitingSender::new(SentMessage::ToAllActors(m));
+                inner.waiting_senders.push_back(Arc::downgrade(&waiting));
+                Err(TrySendFail::Full(waiting))
+            }
+            msg => {
+                let res = inner.try_fulfill_receiver(msg.into());
+                match res {
+                    Ok(()) => Ok(()),
+                    Err(WakeReason::MessageToOneActor(m))
+                        if m.priority == 0 && !self.is_full(inner.ordered_queue.len()) =>
+                    {
+                        inner.ordered_queue.push_back(m.val);
+                        Ok(())
+                    }
+                    Err(WakeReason::MessageToOneActor(m))
+                        if m.priority != 0 && !self.is_full(inner.priority_queue.len()) =>
+                    {
+                        inner.priority_queue.push(m);
+                        Ok(())
+                    }
+                    Err(WakeReason::MessageToOneActor(m)) => {
+                        let waiting = WaitingSender::new(m.into());
+                        inner.waiting_senders.push_back(Arc::downgrade(&waiting));
+                        Err(TrySendFail::Full(waiting))
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
     fn is_full(&self, len: usize) -> bool {
         self.capacity.map_or(false, |cap| len >= cap)
     }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -46,14 +46,7 @@ pub struct Chan<A> {
 impl<A> Chan<A> {
     fn new(capacity: Option<usize>) -> Self {
         Self {
-            chan: Mutex::new(ChanInner {
-                ordered_queue: VecDeque::new(),
-                waiting_senders: VecDeque::new(),
-                waiting_receivers: VecDeque::new(),
-                priority_queue: BinaryHeap::new(),
-                broadcast_queues: Vec::new(),
-                broadcast_tail: 0,
-            }),
+            chan: Mutex::new(ChanInner::default()),
             capacity,
             on_shutdown: Event::new(),
             sender_count: AtomicUsize::new(0),
@@ -259,6 +252,20 @@ struct ChanInner<A> {
     priority_queue: BinaryHeap<PriorityMessageToOne<A>>,
     broadcast_queues: Vec<Weak<BroadcastQueue<A>>>,
     broadcast_tail: usize,
+}
+
+// Manual impl to avoid `A: Default` bound.
+impl<A> Default for ChanInner<A> {
+    fn default() -> Self {
+        Self {
+            ordered_queue: VecDeque::default(),
+            waiting_senders: VecDeque::default(),
+            waiting_receivers: VecDeque::default(),
+            priority_queue: BinaryHeap::default(),
+            broadcast_queues: Vec::default(),
+            broadcast_tail: 0,
+        }
+    }
 }
 
 impl<A> ChanInner<A> {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -182,7 +182,7 @@ impl<A> ChanInner<A> {
             };
 
             if let Some(tx) = self.waiting_senders.remove(pos).unwrap().upgrade() {
-                return Some(tx.lock().fulfill_as_delivered());
+                return Some(tx.lock().fulfill());
             }
         }
     }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -26,7 +26,7 @@ type BroadcastQueue<A> = Spinlock<BinaryHeap<MessageToAllActors<A>>>;
 /// Create an actor mailbox, returning a sender and receiver for it. The given capacity is applied
 /// severally to each send type - priority, ordered, and broadcast.
 pub fn new<A>(capacity: Option<usize>) -> (Sender<A, TxStrong>, Receiver<A, RxStrong>) {
-    let broadcast_mailbox = Arc::new(Spinlock::new(BinaryHeap::new()));
+    let broadcast_mailbox = Arc::new(BroadcastQueue::default());
     let inner = Arc::new(Chan {
         chan: Mutex::new(ChanInner {
             ordered_queue: VecDeque::new(),

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -139,7 +139,7 @@ impl<A, Rc: RxRefCounter> Drop for Receiver<A, Rc> {
             };
 
             for tx in waiting_tx.into_iter().flat_map(|w| w.upgrade()) {
-                let _ = tx.lock().fulfill_as_closed();
+                tx.lock().fulfill_as_closed();
             }
         }
     }

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -1,4 +1,3 @@
-use std::collections::BinaryHeap;
 use std::future::Future;
 use std::mem;
 use std::pin::Pin;
@@ -67,17 +66,9 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
 
 impl<A, Rc: RxRefCounter> Clone for Receiver<A, Rc> {
     fn clone(&self) -> Self {
-        let new_mailbox = Arc::new(Spinlock::new(BinaryHeap::new()));
-        self.inner
-            .chan
-            .lock()
-            .unwrap()
-            .broadcast_queues
-            .push(Arc::downgrade(&new_mailbox));
-
         Receiver {
             inner: self.inner.clone(),
-            broadcast_mailbox: new_mailbox,
+            broadcast_mailbox: self.inner.new_broadcast_mailbox(),
             rc: self.rc.increment(&self.inner),
         }
     }

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -47,10 +47,6 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
 
         ReceiveFuture::new(receiver_with_same_broadcast_mailbox)
     }
-
-    fn pop_broadcast_message(&self) -> Option<MessageToAllActors<A>> {
-        self.inner.pop_broadcast_message(&self.broadcast_mailbox)
-    }
 }
 
 impl<A, Rc: RxRefCounter> Clone for Receiver<A, Rc> {
@@ -118,7 +114,7 @@ impl<A, Rc: RxRefCounter> Future for ReceiveFuture<A, Rc> {
                             unreachable!("Waiting receive future cannot be interrupted")
                         }
                         Poll::Ready(WakeReason::MessageToAllActors) => {
-                            match rx.pop_broadcast_message() {
+                            match rx.inner.pop_broadcast_message(&rx.broadcast_mailbox) {
                                 Some(msg) => ActorMessage::ToAllActors(msg.0),
                                 None => {
                                     // We got woken but failed to pop a message, try receiving again.

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -6,7 +6,6 @@ use std::sync::{atomic, Arc};
 use std::task::{Context, Poll, Waker};
 
 use futures_core::FusedFuture;
-use futures_util::FutureExt;
 
 use crate::inbox::tx::TxWeak;
 use crate::inbox::*;
@@ -97,66 +96,68 @@ enum ReceiveFutureInner<A, Rc: RxRefCounter> {
 impl<A, Rc: RxRefCounter> Future for ReceiveFuture<A, Rc> {
     type Output = ActorMessage<A>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ActorMessage<A>> {
-        match mem::replace(&mut self.0, ReceiveFutureInner::Complete) {
-            ReceiveFutureInner::New(rx) => {
-                match rx.inner.try_recv(rx.broadcast_mailbox.as_ref()) {
-                    Ok(message) => Poll::Ready(message),
-                    Err(waiting) => {
-                        // Start waiting. The waiting receiver should be immediately polled, in case a
-                        // send operation happened between `try_recv` and here, in which case the
-                        // WaitingReceiver would be fulfilled, but not properly woken.
-                        self.0 = ReceiveFutureInner::Waiting { rx, waiting };
-                        self.poll_unpin(cx)
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ActorMessage<A>> {
+        let this = self.get_mut();
+
+        loop {
+            match mem::replace(&mut this.0, ReceiveFutureInner::Complete) {
+                ReceiveFutureInner::New(rx) => {
+                    match rx.inner.try_recv(rx.broadcast_mailbox.as_ref()) {
+                        Ok(message) => return Poll::Ready(message),
+                        Err(waiting) => {
+                            // Start waiting. The waiting receiver should be immediately polled, in case a
+                            // send operation happened between `try_recv` and here, in which case the
+                            // WaitingReceiver would be fulfilled, but not properly woken.
+                            this.0 = ReceiveFutureInner::Waiting { rx, waiting };
+                        }
                     }
                 }
-            }
-            ReceiveFutureInner::Waiting { rx, waiting } => {
-                {
-                    let mut inner = waiting.lock();
+                ReceiveFutureInner::Waiting { rx, waiting } => {
+                    {
+                        let mut inner = waiting.lock();
 
-                    match inner.wake_reason.take() {
-                        // Message has been delivered
-                        Some(reason) => {
-                            return Poll::Ready(match reason {
-                                WakeReason::MessageToOneActor(msg) => msg.into(),
-                                WakeReason::MessageToAllActors => {
-                                    // The broadcast message could have been taken by another
-                                    // receive future from the same receiver (or from another
-                                    // receiver sharing the same broadcast mailbox)
-                                    let pop = rx.broadcast_mailbox.lock().pop();
-                                    match pop {
-                                        Some(msg) => {
-                                            rx.inner
-                                                .chan
-                                                .lock()
-                                                .unwrap()
-                                                .try_advance_broadcast_tail(rx.inner.capacity);
-                                            ActorMessage::ToAllActors(msg.0)
-                                        }
-                                        None => {
-                                            // If it was taken, try receive again
-                                            self.0 = ReceiveFutureInner::New(rx);
-                                            drop(inner);
-                                            return self.poll_unpin(cx);
+                        match inner.wake_reason.take() {
+                            // Message has been delivered
+                            Some(reason) => {
+                                return Poll::Ready(match reason {
+                                    WakeReason::MessageToOneActor(msg) => msg.into(),
+                                    WakeReason::MessageToAllActors => {
+                                        // The broadcast message could have been taken by another
+                                        // receive future from the same receiver (or from another
+                                        // receiver sharing the same broadcast mailbox)
+                                        let pop = rx.broadcast_mailbox.lock().pop();
+                                        match pop {
+                                            Some(msg) => {
+                                                rx.inner
+                                                    .chan
+                                                    .lock()
+                                                    .unwrap()
+                                                    .try_advance_broadcast_tail(rx.inner.capacity);
+                                                ActorMessage::ToAllActors(msg.0)
+                                            }
+                                            None => {
+                                                // If it was taken, try receive again
+                                                this.0 = ReceiveFutureInner::New(rx);
+                                                continue;
+                                            }
                                         }
                                     }
-                                }
-                                WakeReason::Shutdown => ActorMessage::Shutdown,
-                                WakeReason::Cancelled => {
-                                    unreachable!("Waiting receive future cannot be interrupted")
-                                }
-                            });
+                                    WakeReason::Shutdown => ActorMessage::Shutdown,
+                                    WakeReason::Cancelled => {
+                                        unreachable!("Waiting receive future cannot be interrupted")
+                                    }
+                                });
+                            }
+                            // Message has not been delivered - continue waiting
+                            None => inner.waker = Some(cx.waker().clone()),
                         }
-                        // Message has not been delivered - continue waiting
-                        None => inner.waker = Some(cx.waker().clone()),
                     }
-                }
 
-                self.0 = ReceiveFutureInner::Waiting { rx, waiting };
-                Poll::Pending
+                    this.0 = ReceiveFutureInner::Waiting { rx, waiting };
+                    return Poll::Pending;
+                }
+                ReceiveFutureInner::Complete => return Poll::Pending,
             }
-            ReceiveFutureInner::Complete => Poll::Pending,
         }
     }
 }

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -139,7 +139,7 @@ impl<A, Rc: RxRefCounter> Drop for Receiver<A, Rc> {
             };
 
             for tx in waiting_tx.into_iter().flat_map(|w| w.upgrade()) {
-                let _ = tx.lock().fulfill(false);
+                let _ = tx.lock().fulfill_as_closed();
             }
         }
     }

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -139,7 +139,7 @@ impl<A, Rc: RxRefCounter> Drop for Receiver<A, Rc> {
             };
 
             for tx in waiting_tx.into_iter().flat_map(|w| w.upgrade()) {
-                tx.lock().fulfill_as_closed();
+                tx.lock().set_closed();
             }
         }
     }

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -17,13 +17,13 @@ pub struct Receiver<A, Rc: RxRefCounter> {
 }
 
 impl<A> Receiver<A, RxStrong> {
-    pub(super) fn new(inner: Arc<Chan<A>>, broadcast_mailbox: Arc<BroadcastQueue<A>>) -> Self {
+    pub(super) fn new(inner: Arc<Chan<A>>) -> Self {
         let rc = RxStrong(());
         rc.increment(&inner);
 
         Receiver {
+            broadcast_mailbox: inner.new_broadcast_mailbox(),
             inner,
-            broadcast_mailbox,
             rc,
         }
     }

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -33,17 +33,11 @@ impl<A> Receiver<A, RxStrong> {
 
 impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
     pub fn sender(&self) -> Option<Sender<A, TxStrong>> {
-        Some(Sender {
-            inner: self.inner.clone(),
-            rc: TxStrong::try_new(&self.inner)?,
-        })
+        Sender::try_new_strong(self.inner.clone())
     }
 
     pub fn weak_sender(&self) -> Sender<A, TxWeak> {
-        Sender {
-            inner: self.inner.clone(),
-            rc: TxWeak::new(&self.inner),
-        }
+        Sender::new_weak(self.inner.clone())
     }
 
     pub fn receive(&self) -> ReceiveFuture<A, Rc> {

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -49,18 +49,7 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
     }
 
     fn pop_broadcast_message(&self) -> Option<MessageToAllActors<A>> {
-        let message = self.broadcast_mailbox.lock().pop();
-
-        // Advance the broadcast tail if we successfully took a message.
-        if message.is_some() {
-            self.inner
-                .chan
-                .lock()
-                .unwrap()
-                .try_advance_broadcast_tail(self.inner.capacity);
-        }
-
-        message
+        self.inner.pop_broadcast_message(&self.broadcast_mailbox)
     }
 }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -90,21 +90,7 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     }
 
     pub fn disconnect_notice(&self) -> Option<EventListener> {
-        // Listener is created before checking connectivity to avoid the following race scenario:
-        //
-        // 1. is_connected returns true
-        // 2. on_shutdown is notified
-        // 3. listener is registered
-        //
-        // The listener would never be woken in this scenario, as the notification preceded its
-        // creation.
-        let listener = self.inner.on_shutdown.listen();
-
-        if self.is_connected() {
-            Some(listener)
-        } else {
-            None
-        }
+        self.inner.disconnect_listener()
     }
 }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -27,6 +27,20 @@ impl<A> Sender<A, TxStrong> {
 
         Sender { inner, rc }
     }
+
+    pub fn try_new_strong(inner: Arc<Chan<A>>) -> Option<Self> {
+        let rc = TxStrong::try_new(&inner)?;
+
+        Some(Self { inner, rc })
+    }
+}
+
+impl<A> Sender<A, TxWeak> {
+    pub fn new_weak(inner: Arc<Chan<A>>) -> Self {
+        let rc = TxWeak::new(&inner);
+
+        Sender { inner, rc }
+    }
 }
 
 impl<Rc: TxRefCounter, A> Sender<A, Rc> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -31,10 +31,6 @@ impl<A> Sender<A, TxStrong> {
 
 impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     fn try_send(&self, message: SentMessage<A>) -> Result<(), TrySendFail<A>> {
-        if !self.is_connected() {
-            return Err(TrySendFail::Disconnected);
-        }
-
         self.inner.try_send(message)
     }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -188,7 +188,7 @@ impl<A, Rc: TxRefCounter> Debug for Sender<A, Rc> {
 
 #[must_use = "Futures do nothing unless polled"]
 pub struct SendFuture<A, Rc: TxRefCounter> {
-    pub tx: Sender<A, Rc>,
+    tx: Sender<A, Rc>,
     inner: SendFutureInner<A>,
 }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -270,7 +270,7 @@ impl<A> WaitingSender<A> {
         }
     }
 
-    pub fn fulfill_as_delivered(&mut self) -> SentMessage<A> {
+    pub fn fulfill(&mut self) -> SentMessage<A> {
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }
@@ -281,7 +281,10 @@ impl<A> WaitingSender<A> {
         }
     }
 
-    pub fn fulfill_as_closed(&mut self) {
+    /// Mark this [`WaitingSender`] as closed.
+    ///
+    /// Should be called when the last [`Receiver`](crate::inbox::Receiver) goes away.
+    pub fn set_closed(&mut self) {
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -281,15 +281,12 @@ impl<A> WaitingSender<A> {
         }
     }
 
-    pub fn fulfill_as_closed(&mut self) -> SentMessage<A> {
+    pub fn fulfill_as_closed(&mut self) {
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }
 
-        match mem::replace(&mut self.message, WaitingSenderInner::Closed) {
-            WaitingSenderInner::New(msg) => msg,
-            _ => panic!("WaitingSender should have message"),
-        }
+        self.message = WaitingSenderInner::Closed;
     }
 }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -270,18 +270,23 @@ impl<A> WaitingSender<A> {
         }
     }
 
-    pub fn fulfill(&mut self, is_delivered: bool) -> SentMessage<A> {
+    pub fn fulfill_as_delivered(&mut self) -> SentMessage<A> {
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }
 
-        let new = if is_delivered {
-            WaitingSenderInner::Delivered
-        } else {
-            WaitingSenderInner::Closed
-        };
+        match mem::replace(&mut self.message, WaitingSenderInner::Delivered) {
+            WaitingSenderInner::New(msg) => msg,
+            _ => panic!("WaitingSender should have message"),
+        }
+    }
 
-        match mem::replace(&mut self.message, new) {
+    pub fn fulfill_as_closed(&mut self) -> SentMessage<A> {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+
+        match mem::replace(&mut self.message, WaitingSenderInner::Closed) {
             WaitingSenderInner::New(msg) => msg,
             _ => panic!("WaitingSender should have message"),
         }

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -87,6 +87,13 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     pub fn disconnect_notice(&self) -> Option<EventListener> {
         self.inner.disconnect_listener()
     }
+
+    /// Send a message through with [`Sender`].
+    ///
+    /// This consumes the provided [`Sender`] but it can be cloned before it one wishes to reuse it.
+    pub fn send(self, msg: SentMessage<A>) -> SendFuture<A, Rc> {
+        SendFuture::New { msg, tx: self }
+    }
 }
 
 impl<A, Rc: TxRefCounter> Clone for Sender<A, Rc> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -72,8 +72,7 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     }
 
     pub fn is_connected(&self) -> bool {
-        self.inner.receiver_count.load(atomic::Ordering::SeqCst) > 0
-            && self.inner.sender_count.load(atomic::Ordering::SeqCst) > 0
+        self.inner.is_connected()
     }
 
     pub fn capacity(&self) -> Option<usize> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -10,7 +10,6 @@ use futures_core::FusedFuture;
 use futures_util::FutureExt;
 
 use super::*;
-use crate::envelope::Shutdown;
 use crate::inbox::tx::private::RefCounterInner;
 use crate::send_future::private::SetPriority;
 use crate::{Actor, Error};
@@ -48,11 +47,7 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     where
         A: Actor,
     {
-        self.inner
-            .chan
-            .lock()
-            .unwrap()
-            .send_broadcast(MessageToAllActors(Arc::new(Shutdown::new())));
+        self.inner.shutdown_all_receivers()
     }
 
     pub fn downgrade(&self) -> Sender<A, TxWeak> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -80,8 +80,7 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     }
 
     pub fn len(&self) -> usize {
-        let inner = self.inner.chan.lock().unwrap();
-        inner.broadcast_tail + inner.ordered_queue.len() + inner.priority_queue.len()
+        self.inner.len()
     }
 
     pub fn disconnect_notice(&self) -> Option<EventListener> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -16,8 +16,8 @@ use crate::send_future::private::SetPriority;
 use crate::{Actor, Error};
 
 pub struct Sender<A, Rc: TxRefCounter> {
-    pub(super) inner: Arc<Chan<A>>,
-    pub(super) rc: Rc,
+    inner: Arc<Chan<A>>,
+    rc: Rc,
 }
 
 impl<A> Sender<A, TxStrong> {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -86,10 +86,6 @@ impl<Rc: TxRefCounter, A> Sender<A, Rc> {
             .send_broadcast(MessageToAllActors(Arc::new(Shutdown::new())));
     }
 
-    pub fn send(&self, message: SentMessage<A>) -> SendFuture<A, Rc> {
-        SendFuture::new(message, self.clone())
-    }
-
     pub fn downgrade(&self) -> Sender<A, TxWeak> {
         Sender {
             inner: self.inner.clone(),
@@ -197,7 +193,7 @@ pub struct SendFuture<A, Rc: TxRefCounter> {
 }
 
 impl<A, Rc: TxRefCounter> SendFuture<A, Rc> {
-    fn new(msg: SentMessage<A>, tx: Sender<A, Rc>) -> Self {
+    pub fn new(msg: SentMessage<A>, tx: Sender<A, Rc>) -> Self {
         SendFuture {
             tx,
             inner: SendFutureInner::New(msg),

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -31,11 +31,11 @@ impl<A> Sender<A, TxStrong> {
 
 impl<Rc: TxRefCounter, A> Sender<A, Rc> {
     fn try_send(&self, message: SentMessage<A>) -> Result<(), TrySendFail<A>> {
-        let mut inner = self.inner.chan.lock().unwrap();
-
         if !self.is_connected() {
             return Err(TrySendFail::Disconnected);
         }
+
+        let mut inner = self.inner.chan.lock().unwrap();
 
         match message {
             SentMessage::ToAllActors(m) if !self.inner.is_full(inner.broadcast_tail) => {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -44,10 +44,6 @@ impl<A> Sender<A, TxWeak> {
 }
 
 impl<Rc: TxRefCounter, A> Sender<A, Rc> {
-    fn try_send(&self, message: SentMessage<A>) -> Result<(), TrySendFail<A>> {
-        self.inner.try_send(message)
-    }
-
     pub fn stop_all_receivers(&self)
     where
         A: Actor,
@@ -172,7 +168,7 @@ impl<A, Rc: TxRefCounter> Future for SendFuture<A, Rc> {
 
         loop {
             match mem::replace(this, SendFuture::Complete) {
-                SendFuture::New { msg, tx } => match tx.try_send(msg) {
+                SendFuture::New { msg, tx } => match tx.inner.try_send(msg) {
                     Ok(()) => return Poll::Ready(Ok(())),
                     Err(TrySendFail::Disconnected) => return Poll::Ready(Err(Error::Disconnected)),
                     Err(TrySendFail::Full(waiting)) => {

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -8,7 +8,7 @@ use futures_sink::Sink;
 
 use crate::address::{ActorJoinHandle, Address};
 use crate::envelope::ReturningEnvelope;
-use crate::inbox::{PriorityMessageToOne, SentMessage};
+use crate::inbox::{tx, PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::{ActorErasedSending, ResolveToHandlerReturn, SendFuture};
 use crate::{Error, Handler};
@@ -298,7 +298,7 @@ where
     ) -> SendFuture<R, ActorErasedSending<Self::Return>, ResolveToHandlerReturn> {
         let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
         let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let sending = self.0.send(SentMessage::ToOneActor(msg));
+        let sending = tx::SendFuture::new(SentMessage::ToOneActor(msg), self.0.clone());
 
         SendFuture::sending_erased(sending, rx)
     }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -7,8 +7,6 @@ use std::fmt;
 use futures_sink::Sink;
 
 use crate::address::{ActorJoinHandle, Address};
-use crate::envelope::ReturningEnvelope;
-use crate::inbox::{tx, PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::{ActorErasedSending, ResolveToHandlerReturn, SendFuture};
 use crate::{Error, Handler};
@@ -296,11 +294,7 @@ where
         &self,
         message: M,
     ) -> SendFuture<R, ActorErasedSending<Self::Return>, ResolveToHandlerReturn> {
-        let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
-        let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let sending = tx::SendFuture::new(SentMessage::ToOneActor(msg), self.0.clone());
-
-        SendFuture::sending_erased(sending, rx)
+        SendFuture::sending_erased(message, self.0.clone())
     }
 
     fn clone_channel(

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -111,6 +111,9 @@ impl<R> SendFuture<R, ActorErasedSending<R>, ResolveToHandlerReturn> {
 }
 
 impl<A, R, Rc: RefCounter> SendFuture<R, NameableSending<A, R, Rc>, ResolveToHandlerReturn> {
+    /// Construct a [`SendFuture`] that contains the actor's name in its type.
+    ///
+    /// Compared to [`SendFuture::sending_erased`], this function avoids one allocation.
     pub(crate) fn sending_named<M>(message: M, sender: inbox::Sender<A, Rc>) -> Self
     where
         A: Handler<M, Return = R>,

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -98,14 +98,10 @@ impl<R> SendFuture<R, ActorErasedSending<R>, ResolveToHandlerReturn> {
     {
         let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
         let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let sending = inbox::SendFuture::New {
-            msg: SentMessage::ToOneActor(msg),
-            tx: sender,
-        };
 
         Self {
             inner: SendFutureInner::Sending(ActorErasedSending {
-                future: Box::new(sending),
+                future: Box::new(sender.send(SentMessage::ToOneActor(msg))),
                 rx: Some(rx),
             }),
             phantom: PhantomData,
@@ -125,14 +121,10 @@ impl<A, R, Rc: RefCounter> SendFuture<R, NameableSending<A, R, Rc>, ResolveToHan
     {
         let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
         let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let send_fut = inbox::SendFuture::New {
-            msg: SentMessage::ToOneActor(msg),
-            tx: sender,
-        };
 
         Self {
             inner: SendFutureInner::Sending(NameableSending {
-                inner: send_fut,
+                inner: sender.send(SentMessage::ToOneActor(msg)),
                 receiver: Some(Receiver::new(rx)),
             }),
             phantom: PhantomData,

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -98,7 +98,10 @@ impl<R> SendFuture<R, ActorErasedSending<R>, ResolveToHandlerReturn> {
     {
         let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
         let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let sending = inbox::SendFuture::new(SentMessage::ToOneActor(msg), sender);
+        let sending = inbox::SendFuture::New {
+            msg: SentMessage::ToOneActor(msg),
+            tx: sender,
+        };
 
         Self {
             inner: SendFutureInner::Sending(ActorErasedSending {
@@ -122,7 +125,10 @@ impl<A, R, Rc: RefCounter> SendFuture<R, NameableSending<A, R, Rc>, ResolveToHan
     {
         let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
         let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let send_fut = inbox::SendFuture::new(SentMessage::ToOneActor(msg), sender);
+        let send_fut = inbox::SendFuture::New {
+            msg: SentMessage::ToOneActor(msg),
+            tx: sender,
+        };
 
         Self {
             inner: SendFutureInner::Sending(NameableSending {

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -117,15 +117,14 @@ impl<A, R, Rc: RefCounter> SendFuture<R, NameableSending<A, R, Rc>, ResolveToHan
         M: Send + 'static,
         R: Send + 'static,
     {
-        let (envelope, receiver) =
-            ReturningEnvelope::<A, M, <A as Handler<M>>::Return>::new(message);
-        let msg = SentMessage::ToOneActor(PriorityMessageToOne::new(0, Box::new(envelope)));
-        let send_fut = inbox::SendFuture::new(msg, sender);
+        let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
+        let msg = PriorityMessageToOne::new(0, Box::new(envelope));
+        let send_fut = inbox::SendFuture::new(SentMessage::ToOneActor(msg), sender);
 
         Self {
             inner: SendFutureInner::Sending(NameableSending {
                 inner: send_fut,
-                receiver: Some(Receiver::new(receiver)),
+                receiver: Some(Receiver::new(rx)),
             }),
             phantom: PhantomData,
         }


### PR DESCRIPTION
As part of trying to come up with an alternative to https://github.com/Restioson/xtra/pull/120, I started to move a bit of code around and ended up with this patch set!

Each commit in its own builds and has passing tests and I was careful to try and not alter any behaviour. In other words, this is a pure refactoring.

The goal was as follows:

- Have `Chan` house the core channel implementation with descriptive function names for key operations
- Have `Sender` and `Receiver` be thin layers on top that combine `Chan` with reference counting and provide a `Future`-based APIs for sending and receiving

I can extract some of these commits into individual PRs if you want. The diff will be quite hard to follow once it is squashed.