### PR TITLE
Remove legacy doc attributes from `Context::join`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -194,9 +194,6 @@ impl<A: Actor> Context<A> {
     /// assert!(addr.is_connected());
     /// assert_eq!(addr.send(Joining).await, Ok(true)); // Assert that the join did evaluate the future
     /// # })
-    #[cfg_attr(docsrs, doc("```"))]
-    #[cfg_attr(docsrs, doc(include = "../examples/interleaved_messages.rs"))]
-    #[cfg_attr(docsrs, doc("```"))]
     pub async fn join<F, R>(&mut self, actor: &mut A, fut: F) -> R
     where
         F: Future<Output = R>,


### PR DESCRIPTION
These annotations generate a warning when compiling the docs with
a nightly compiler. We also do now have a separate example in the
documentation of this function so embedding the other example is
not necessary.