### PR TITLE
Introduce optional `sink` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.60.0"
 async-trait = "0.1.56"
 catty = "0.1.5"
 futures-core = { version = "0.3.21", default-features = false, features = ["alloc"] }
-futures-sink = { version = "0.3.21", default-features = false }
-futures-util = { version = "0.3.21", default-features = false, features = ["sink", "alloc"] }
+futures-sink = { version = "0.3.21", default-features = false, optional = true }
+futures-util = { version = "0.3.21", default-features = false, features = ["alloc"] }
 pin-project-lite = "0.2.9"
 event-listener = "2.4.0"
 spin = { version = "0.9.3", default-features = false, features = ["spin_mutex"] }
@@ -48,6 +48,7 @@ async_std = ["dep:async-std"]
 smol = ["dep:smol"]
 tokio = ["dep:tokio"]
 wasm_bindgen = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures"]
+sink = ["dep:futures-sink", "futures-util/sink"]
 
 [[example]]
 name = "basic_tokio"
@@ -84,7 +85,7 @@ required-features = ["tokio"]
 
 [[example]]
 name = "address_sink"
-required-features = ["tokio", "tokio/full"]
+required-features = ["tokio", "tokio/full", "sink"]
 
 [[example]]
 name = "send_interval"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Keep in mind that `xtra` has a MSRV of 1.60.0.
 - `with-tracing-0_1`: enables the `Instrumented` wrapper and `InstrumentedExt` traits, to integrate with
   [tracing](https://tracing.rs). This allows a tracing span to follow through execution of a message, either as a child
   of the sending span, or as a separate span marked as `follows_from` the sending span.
+- `sink`: Adds `Address::into_sink` and `MessageChannel::into_sink`.
 
 ## Latest Breaking Changes
 To see the breaking changes for each version, see [here](https://github.com/Restioson/xtra/blob/master/BREAKING-CHANGES.md).

--- a/src/address.rs
+++ b/src/address.rs
@@ -9,14 +9,13 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use event_listener::EventListener;
-use futures_sink::Sink;
 use futures_util::FutureExt;
 
 use crate::envelope::ReturningEnvelope;
 use crate::inbox::{PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::ResolveToHandlerReturn;
-use crate::{inbox, BroadcastFuture, Error, Handler, NameableSending, SendFuture};
+use crate::{inbox, BroadcastFuture, Handler, NameableSending, SendFuture};
 
 /// An [`Address`] is a reference to an actor through which messages can be
 /// sent. It can be cloned to create more addresses to the same actor.
@@ -217,7 +216,10 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     ///
     /// Because [`Sink`]s do not return anything, this function is only available for messages with
     /// a [`Handler`] implementation that sets [`Return`](Handler::Return) to `()`.
-    pub fn into_sink<M>(self) -> impl Sink<M, Error = Error>
+    ///
+    /// [`Sink`]: futures_sink::Sink
+    #[cfg(feature = "sink")]
+    pub fn into_sink<M>(self) -> impl futures_sink::Sink<M, Error = crate::Error>
     where
         A: Handler<M, Return = ()>,
         M: Send + 'static,

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -4,14 +4,12 @@
 
 use std::fmt;
 
-use futures_sink::Sink;
-
 use crate::address::{ActorJoinHandle, Address};
 use crate::envelope::ReturningEnvelope;
 use crate::inbox::{PriorityMessageToOne, SentMessage};
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::{ActorErasedSending, ResolveToHandlerReturn, SendFuture};
-use crate::{Error, Handler};
+use crate::Handler;
 
 /// A message channel is a channel through which you can send only one kind of message, but to
 /// any actor that can handle it. It is like [`Address`], but associated with the message type rather
@@ -142,6 +140,7 @@ where
     }
 }
 
+#[cfg(feature = "sink")]
 impl<M, Rc> MessageChannel<M, (), Rc>
 where
     M: Send + 'static,
@@ -156,7 +155,7 @@ where
     ///
     /// The provided [`Sink`] will process one message at a time completely and thus enforces
     /// back-pressure according to the bounds of the actor's mailbox.
-    pub fn into_sink(self) -> impl Sink<M, Error = Error> {
+    pub fn into_sink(self) -> impl futures_sink::Sink<M, Error = crate::Error> {
         futures_util::sink::unfold((), move |(), message| self.send(message))
     }
 }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -155,6 +155,8 @@ where
     ///
     /// The provided [`Sink`] will process one message at a time completely and thus enforces
     /// back-pressure according to the bounds of the actor's mailbox.
+    ///
+    /// [`Sink`]: futures_sink::Sink
     pub fn into_sink(self) -> impl futures_sink::Sink<M, Error = crate::Error> {
         futures_util::sink::unfold((), move |(), message| self.send(message))
     }


### PR DESCRIPTION
Not every user may need the `sink` feature and we can minimise
our dependency tree in those cases.