### PR TITLE
Inline `Sender` into `Address`

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -162,25 +162,25 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
         message: M,
     ) -> SendFuture<
         <A as Handler<M>>::Return,
-        NameableSending<A, <A as Handler<M>>::Return, Rc>,
+        NameableSending<A, <A as Handler<M>>::Return>,
         ResolveToHandlerReturn,
     >
     where
         M: Send + 'static,
         A: Handler<M>,
     {
-        SendFuture::sending_named(message, self.0.clone())
+        SendFuture::sending_named(message, self.0.inner.clone())
     }
 
     /// Send a message to all actors on this address.
     ///
     /// For details, please see the documentation on [`BroadcastFuture`].
-    pub fn broadcast<M>(&self, msg: M) -> BroadcastFuture<A, M, Rc>
+    pub fn broadcast<M>(&self, msg: M) -> BroadcastFuture<A, M>
     where
         M: Clone + Sync + Send + 'static,
         A: Handler<M, Return = ()>,
     {
-        BroadcastFuture::new(msg, self.0.clone())
+        BroadcastFuture::new(msg, self.0.inner.clone())
     }
 
     /// Waits until this address becomes disconnected. Note that if this is called on a strong

--- a/src/address.rs
+++ b/src/address.rs
@@ -13,10 +13,10 @@ use event_listener::EventListener;
 use futures_sink::Sink;
 use futures_util::FutureExt;
 
+use crate::inbox::Chan;
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::ResolveToHandlerReturn;
 use crate::{BroadcastFuture, Error, Handler, NameableSending, SendFuture};
-use crate::inbox::Chan;
 
 /// An [`Address`] is a reference to an actor through which messages can be
 /// sent. It can be cloned to create more addresses to the same actor.
@@ -94,7 +94,7 @@ impl<A> Address<A, Strong> {
     pub fn downgrade(&self) -> WeakAddress<A> {
         Address {
             inner: self.inner.clone(),
-            rc: Weak::new(&self.inner)
+            rc: Weak::new(&self.inner),
         }
     }
 }
@@ -105,7 +105,7 @@ impl<A> Address<A, Either> {
     pub fn downgrade(&self) -> WeakAddress<A> {
         Address {
             inner: self.inner.clone(),
-            rc: Weak::new(&self.inner)
+            rc: Weak::new(&self.inner),
         }
     }
 }
@@ -164,7 +164,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     pub fn as_either(&self) -> Address<A, Either> {
         Address {
             inner: self.inner.clone(),
-            rc: self.rc.increment(&self.inner).into_either()
+            rc: self.rc.increment(&self.inner).into_either(),
         }
     }
 
@@ -267,7 +267,7 @@ impl<A, Rc: RefCounter> Clone for Address<A, Rc> {
     fn clone(&self) -> Self {
         Address {
             inner: self.inner.clone(),
-            rc: self.rc.increment(&self.inner)
+            rc: self.rc.increment(&self.inner),
         }
     }
 }
@@ -291,10 +291,12 @@ impl<A, Rc: RefCounter> Eq for Address<A, Rc> {}
 /// address will compare as greater than a weak one.
 impl<A, Rc: RefCounter, Rc2: RefCounter> PartialOrd<Address<A, Rc2>> for Address<A, Rc> {
     fn partial_cmp(&self, other: &Address<A, Rc2>) -> Option<Ordering> {
-        Some(match Arc::as_ptr(&self.inner).cmp(&Arc::as_ptr(&other.inner)) {
-            Ordering::Equal => self.rc.is_strong().cmp(&other.rc.is_strong()),
-            ord => ord,
-        })
+        Some(
+            match Arc::as_ptr(&self.inner).cmp(&Arc::as_ptr(&other.inner)) {
+                Ordering::Equal => self.rc.is_strong().cmp(&other.rc.is_strong()),
+                ord => ord,
+            },
+        )
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,9 +2,9 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Poll;
 use std::{mem, task};
-use std::sync::Arc;
 
 use futures_core::future::BoxFuture;
 use futures_core::FusedFuture;
@@ -13,9 +13,9 @@ use futures_util::FutureExt;
 
 use crate::envelope::{HandlerSpan, Shutdown};
 use crate::inbox::rx::{ReceiveFuture as InboxReceiveFuture, RxStrong};
+use crate::inbox::tx::{TxStrong, TxWeak};
 use crate::inbox::{ActorMessage, Chan};
 use crate::{inbox, Actor, Address, Error, WeakAddress};
-use crate::inbox::tx::{TxStrong, TxWeak};
 
 /// `Context` is used to control how the actor is managed and to get the actor's address from inside
 /// of a message handler. Keep in mind that if a free-floating `Context` (i.e not running an actor via

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -208,7 +208,7 @@ impl<A> Chan<A> {
             .send_broadcast(MessageToAllActors(Arc::new(Shutdown::new())));
     }
 
-    /// Shutdown all [`WaitingSender`](crate::inbox::tx::WaitingSender)s in this channel.
+    /// Shutdown all [`WaitingSender`](crate::inbox::WaitingSender)s in this channel.
     fn shutdown_waiting_senders(&self) {
         let waiting_tx = {
             let mut inner = match self.chan.lock() {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -15,10 +15,10 @@ use std::{cmp, mem};
 
 use event_listener::{Event, EventListener};
 pub use rx::Receiver;
-pub use tx::{SendFuture};
+pub use tx::SendFuture;
 
 use crate::envelope::{BroadcastEnvelope, MessageEnvelope, Shutdown};
-use crate::inbox::rx::{WaitingReceiver};
+use crate::inbox::rx::WaitingReceiver;
 use crate::{Actor, Error};
 
 type Spinlock<T> = spin::Mutex<T>;

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -151,7 +151,7 @@ impl<A> Chan<A> {
             // Equal, but both are empty, so wait or exit if shutdown
             _ => {
                 // on_shutdown is only notified with inner locked, and it's locked here, so no race
-                if self.sender_count.load(atomic::Ordering::SeqCst) == 0 {
+                if self.sender_count() == 0 {
                     return Ok(ActorMessage::Shutdown);
                 }
 
@@ -163,8 +163,15 @@ impl<A> Chan<A> {
     }
 
     fn is_connected(&self) -> bool {
-        self.receiver_count.load(atomic::Ordering::SeqCst) > 0
-            && self.sender_count.load(atomic::Ordering::SeqCst) > 0
+        self.receiver_count() > 0 && self.sender_count() > 0
+    }
+
+    fn sender_count(&self) -> usize {
+        self.sender_count.load(atomic::Ordering::SeqCst)
+    }
+
+    fn receiver_count(&self) -> usize {
+        self.receiver_count.load(atomic::Ordering::SeqCst)
     }
 
     fn len(&self) -> usize {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug};
+use std::fmt::Debug;
 use std::future::Future;
 use std::mem;
 use std::pin::Pin;
@@ -11,7 +11,7 @@ use futures_util::FutureExt;
 use super::*;
 use crate::inbox::tx::private::RefCounterInner;
 use crate::send_future::private::SetPriority;
-use crate::{Error};
+use crate::Error;
 
 impl<A> SetPriority for SendFuture<A> {
     fn set_priority(&mut self, priority: u32) {

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -1,121 +1,17 @@
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug};
 use std::future::Future;
 use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use event_listener::EventListener;
 use futures_core::FusedFuture;
 use futures_util::FutureExt;
 
 use super::*;
 use crate::inbox::tx::private::RefCounterInner;
 use crate::send_future::private::SetPriority;
-use crate::{Actor, Error};
-
-pub struct Sender<A, Rc: TxRefCounter> {
-    pub inner: Arc<Chan<A>>,
-    rc: Rc,
-}
-
-impl<A> Sender<A, TxStrong> {
-    pub fn new(inner: Arc<Chan<A>>) -> Self {
-        Sender {
-            inner,
-            rc: TxStrong::first(&inner),
-        }
-    }
-
-    pub fn try_new_strong(inner: Arc<Chan<A>>) -> Option<Self> {
-        let rc = TxStrong::try_new(&inner)?;
-
-        Some(Self { inner, rc })
-    }
-}
-
-impl<A> Sender<A, TxWeak> {
-    pub fn new_weak(inner: Arc<Chan<A>>) -> Self {
-        let rc = TxWeak::new(&inner);
-
-        Sender { inner, rc }
-    }
-}
-
-impl<Rc: TxRefCounter, A> Sender<A, Rc> {
-    pub fn stop_all_receivers(&self)
-    where
-        A: Actor,
-    {
-        self.inner.shutdown_all_receivers()
-    }
-
-    pub fn downgrade(&self) -> Sender<A, TxWeak> {
-        Sender {
-            inner: self.inner.clone(),
-            rc: TxWeak(()),
-        }
-    }
-
-    pub fn is_strong(&self) -> bool {
-        self.rc.is_strong()
-    }
-
-    pub fn inner_ptr(&self) -> *const Chan<A> {
-        (&self.inner as &Chan<A>) as *const Chan<A>
-    }
-
-    pub fn into_either_rc(self) -> Sender<A, TxEither> {
-        Sender {
-            inner: self.inner.clone(),
-            rc: self.rc.increment(&self.inner).into_either(),
-        }
-    }
-
-    pub fn is_connected(&self) -> bool {
-        self.inner.is_connected()
-    }
-
-    pub fn capacity(&self) -> Option<usize> {
-        self.inner.capacity
-    }
-
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    pub fn disconnect_notice(&self) -> Option<EventListener> {
-        self.inner.disconnect_listener()
-    }
-}
-
-impl<A, Rc: TxRefCounter> Clone for Sender<A, Rc> {
-    fn clone(&self) -> Self {
-        Sender {
-            inner: self.inner.clone(),
-            rc: self.rc.increment(&self.inner),
-        }
-    }
-}
-
-impl<A, Rc: TxRefCounter> Drop for Sender<A, Rc> {
-    fn drop(&mut self) {
-        if self.rc.decrement(&self.inner) {
-            self.inner.shutdown_waiting_receivers()
-        }
-    }
-}
-
-impl<A, Rc: TxRefCounter> Debug for Sender<A, Rc> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let act = std::any::type_name::<A>();
-        f.debug_struct(&format!("Sender<{}>", act))
-            .field("rx_count", &self.inner.receiver_count())
-            .field("tx_count", &self.inner.sender_count())
-            .field("rc", &self.rc)
-            .finish()
-    }
-}
+use crate::{Error};
 
 impl<A> SetPriority for SendFuture<A> {
     fn set_priority(&mut self, priority: u32) {
@@ -203,9 +99,9 @@ pub struct TxWeak(());
 
 impl TxStrong {
     /// Create the first strong reference.
-    pub(crate) fn first(inner: &Chan<A>) -> Self {
+    pub(crate) fn first<A>(inner: &Chan<A>) -> Self {
         let rc = TxStrong(());
-        rc.increment(&inner);
+        rc.increment(inner);
 
         rc
     }

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -21,10 +21,10 @@ pub struct Sender<A, Rc: TxRefCounter> {
 
 impl<A> Sender<A, TxStrong> {
     pub fn new(inner: Arc<Chan<A>>) -> Self {
-        let rc = TxStrong(());
-        rc.increment(&inner);
-
-        Sender { inner, rc }
+        Sender {
+            inner,
+            rc: TxStrong::first(&inner),
+        }
     }
 
     pub fn try_new_strong(inner: Arc<Chan<A>>) -> Option<Self> {
@@ -202,6 +202,14 @@ pub struct TxStrong(());
 pub struct TxWeak(());
 
 impl TxStrong {
+    /// Create the first strong reference.
+    pub(crate) fn first(inner: &Chan<A>) -> Self {
+        let rc = TxStrong(());
+        rc.increment(&inner);
+
+        rc
+    }
+
     /// Attempt to construct a new `TxStrong` pointing to the given `inner` if there are existing
     /// strong references to `inner`. This will return `None` if there were 0 strong references to
     /// the inner.

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::mem;
 use std::pin::Pin;
-use std::sync::{atomic, Arc};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use event_listener::EventListener;
@@ -115,12 +115,10 @@ impl<A, Rc: TxRefCounter> Drop for Sender<A, Rc> {
 
 impl<A, Rc: TxRefCounter> Debug for Sender<A, Rc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        use atomic::Ordering::SeqCst;
-
         let act = std::any::type_name::<A>();
         f.debug_struct(&format!("Sender<{}>", act))
-            .field("rx_count", &self.inner.receiver_count.load(SeqCst))
-            .field("tx_count", &self.inner.sender_count.load(SeqCst))
+            .field("rx_count", &self.inner.receiver_count())
+            .field("tx_count", &self.inner.sender_count())
             .field("rc", &self.rc)
             .finish()
     }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -8,10 +8,10 @@ use std::sync::Arc;
 use futures_sink::Sink;
 
 use crate::address::{ActorJoinHandle, Address};
+use crate::inbox::tx::TxWeak;
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::{ActorErasedSending, ResolveToHandlerReturn, SendFuture};
 use crate::{Error, Handler};
-use crate::inbox::tx::TxWeak;
 
 /// A message channel is a channel through which you can send only one kind of message, but to
 /// any actor that can handle it. It is like [`Address`], but associated with the message type rather
@@ -322,7 +322,7 @@ where
     ) -> Box<dyn MessageChannelTrait<M, Weak, Return = Self::Return> + Send + Sync + 'static> {
         Box::new(Address {
             inner: self.inner.clone(),
-            rc: TxWeak::new(&self.inner)
+            rc: TxWeak::new(&self.inner),
         })
     }
 

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -294,7 +294,7 @@ where
         &self,
         message: M,
     ) -> SendFuture<R, ActorErasedSending<Self::Return>, ResolveToHandlerReturn> {
-        SendFuture::sending_erased(message, self.0.clone())
+        SendFuture::sending_erased(message, self.0.inner.clone())
     }
 
     fn clone_channel(

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -842,16 +842,14 @@ fn address_debug() {
 
     assert_eq!(
         format!("{:?}", addr1),
-        "Address(Sender<basic::Greeter> { \
-        rx_count: 1, tx_count: 2, rc: TxStrong(()) })"
+        "Address<basic::Greeter> { rx_count: 1, tx_count: 2, rc: TxStrong(()) }"
     );
 
     assert_eq!(format!("{:?}", addr1), format!("{:?}", addr2));
 
     assert_eq!(
         format!("{:?}", weak_addr),
-        "Address(Sender<basic::Greeter> { \
-        rx_count: 1, tx_count: 2, rc: TxWeak(()) })"
+        "Address<basic::Greeter> { rx_count: 1, tx_count: 2, rc: TxWeak(()) }"
     );
 }
 
@@ -865,14 +863,14 @@ fn message_channel_debug() {
     assert_eq!(
         format!("{:?}", mc),
         "MessageChannel<basic::Hello, alloc::string::String>(\
-            Sender<basic::Greeter> { rx_count: 1, tx_count: 1, rc: TxStrong(()) }\
+            Address<basic::Greeter> { rx_count: 1, tx_count: 1, rc: TxStrong(()) }\
         )"
     );
 
     assert_eq!(
         format!("{:?}", weak_mc),
         "MessageChannel<basic::Hello, alloc::string::String>(\
-            Sender<basic::Greeter> { rx_count: 1, tx_count: 1, rc: TxWeak(()) }\
+            Address<basic::Greeter> { rx_count: 1, tx_count: 1, rc: TxWeak(()) }\
         )"
     );
 }


### PR DESCRIPTION
Another step towards #126.

What is interesting about this patch-set is that it removes the reference count from `SendFuture` and `BroadcastFuture`. I think this is okay?