### PR TITLE
Always store message priority in envelope

### DIFF
--- a/src/broadcast_future.rs
+++ b/src/broadcast_future.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -10,6 +9,7 @@ use futures_util::FutureExt;
 use crate::envelope::BroadcastEnvelopeConcrete;
 use crate::inbox::tx::TxRefCounter;
 use crate::inbox::{SendFuture, SentMessage};
+use crate::send_future::private::SetPriority;
 use crate::{inbox, Error, Handler};
 
 /// A [`Future`] that represents the state of broadcasting a message to all actors connected to an
@@ -23,96 +23,53 @@ use crate::{inbox, Error, Handler};
 /// case the mailbox of an actor is bounded, this future yields `Pending` until a slot for this
 /// message is available.
 #[must_use = "Futures do nothing unless polled"]
-pub struct BroadcastFuture<A, M, Rc: TxRefCounter> {
-    inner: Inner<A, M, Rc>,
+pub struct BroadcastFuture<A, Rc: TxRefCounter> {
+    inner: SendFuture<A, Rc>,
 }
 
-impl<A, M, Rc> BroadcastFuture<A, M, Rc>
+impl<A, Rc> BroadcastFuture<A, Rc>
 where
     Rc: TxRefCounter,
 {
-    pub(crate) fn new(message: M, sender: inbox::Sender<A, Rc>) -> Self {
+    pub(crate) fn new<M>(message: M, sender: inbox::Sender<A, Rc>) -> Self
+    where
+        A: Handler<M, Return = ()>,
+        M: Clone + Send + Sync + 'static,
+    {
+        let envelope = BroadcastEnvelopeConcrete::<A, M>::new(message, 0);
+
         Self {
-            inner: Inner::Initial {
-                message,
-                sender,
-                priority: None,
-            },
+            inner: sender.send(SentMessage::ToAllActors(Arc::new(envelope))),
         }
     }
 
     /// Set the priority of this broadcast.
     ///
     /// By default, broadcasts are sent with a priority of 0.
-    pub fn priority(self, priority: u32) -> Self {
-        match self.inner {
-            Inner::Initial {
-                message, sender, ..
-            } => Self {
-                inner: Inner::Initial {
-                    message,
-                    sender,
-                    priority: Some(priority),
-                },
-            },
-            _ => panic!("setting priority after polling is unsupported"),
-        }
+    pub fn priority(mut self, priority: u32) -> Self {
+        self.inner.set_priority(priority);
+
+        self
     }
 }
 
-enum Inner<A, M, Rc: TxRefCounter> {
-    Initial {
-        message: M,
-        sender: inbox::Sender<A, Rc>,
-        priority: Option<u32>,
-    },
-    Sending(SendFuture<A, Rc>),
-    Done,
-}
-
-impl<A, M, Rc> Future for BroadcastFuture<A, M, Rc>
+impl<A, Rc> Future for BroadcastFuture<A, Rc>
 where
     Rc: TxRefCounter,
-    M: Clone + Send + Sync + 'static + Unpin,
-    A: Handler<M, Return = ()>,
 {
     type Output = Result<(), Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-
-        match mem::replace(&mut this.inner, Inner::Done) {
-            Inner::Initial {
-                message,
-                sender,
-                priority,
-            } => {
-                let envelope =
-                    BroadcastEnvelopeConcrete::<A, M>::new(message, priority.unwrap_or(0));
-                this.inner =
-                    Inner::Sending(sender.send(SentMessage::ToAllActors(Arc::new(envelope))));
-                this.poll_unpin(cx)
-            }
-            Inner::Sending(mut send_fut) => match send_fut.poll_unpin(cx) {
-                Poll::Ready(result) => Poll::Ready(result),
-                Poll::Pending => {
-                    this.inner = Inner::Sending(send_fut);
-                    Poll::Pending
-                }
-            },
-            Inner::Done => {
-                panic!("Polled after completion")
-            }
-        }
+        self.get_mut().inner.poll_unpin(cx)
     }
 }
 
-impl<A, M, Rc> FusedFuture for BroadcastFuture<A, M, Rc>
+impl<A, Rc> FusedFuture for BroadcastFuture<A, Rc>
 where
     Rc: TxRefCounter,
     Self: Future,
 {
     fn is_terminated(&self) -> bool {
-        matches!(self.inner, Inner::Done)
+        self.inner.is_terminated()
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -17,9 +17,11 @@ use crate::{Actor, Handler};
 /// allows us to erase the type of the message when this is in dyn Trait format, thereby being able to
 /// use only one channel to send all the kinds of messages that the actor can receives. This does,
 /// however, induce a bit of allocation (as envelopes have to be boxed).
-pub trait MessageEnvelope: Send {
+pub trait MessageEnvelope: HasPriority + Send {
     /// The type of actor that this envelope carries a message for
     type Actor;
+
+    fn set_priority(&self, new_priority: u32);
 
     /// Handle the message inside of the box by calling the relevant `AsyncHandler::handle` or
     /// `Handler::handle` method, returning its result over a return channel if applicable. The
@@ -140,21 +142,35 @@ impl Instrumentation {
 pub struct ReturningEnvelope<A, M, R> {
     message: M,
     result_sender: Sender<R>,
+    priority: spin::Mutex<u32>,
     phantom: PhantomData<for<'a> fn(&'a A)>,
     instrumentation: Instrumentation,
 }
 
 impl<A, M, R: Send + 'static> ReturningEnvelope<A, M, R> {
-    pub fn new(message: M) -> (Self, Receiver<R>) {
+    pub fn new(message: M, priority: u32) -> (Self, Receiver<R>) {
         let (tx, rx) = catty::oneshot();
         let envelope = ReturningEnvelope {
             message,
             result_sender: tx,
+            priority: spin::Mutex::new(priority),
             phantom: PhantomData,
             instrumentation: Instrumentation::new::<A, M>(),
         };
 
         (envelope, rx)
+    }
+}
+
+impl<A, M, R> HasPriority for ReturningEnvelope<A, M, R> {
+    fn priority(&self) -> Priority {
+        Priority::Valued(*self.priority.lock())
+    }
+}
+
+impl<A> HasPriority for Box<dyn MessageEnvelope<Actor = A>> {
+    fn priority(&self) -> Priority {
+        self.as_ref().priority()
     }
 }
 
@@ -165,6 +181,10 @@ where
     R: Send + 'static,
 {
     type Actor = A;
+
+    fn set_priority(&self, new_priority: u32) {
+        *self.priority.lock() = new_priority;
+    }
 
     fn handle<'a>(
         self: Box<Self>,
@@ -196,6 +216,8 @@ where
 pub trait BroadcastEnvelope: HasPriority + Send + Sync {
     type Actor;
 
+    fn set_priority(&self, new_priority: u32);
+
     fn handle<'a>(
         self: Arc<Self>,
         act: &'a mut Self::Actor,
@@ -203,9 +225,15 @@ pub trait BroadcastEnvelope: HasPriority + Send + Sync {
     ) -> (BoxFuture<'a, ControlFlow<()>>, HandlerSpan);
 }
 
+impl<A> HasPriority for Arc<dyn BroadcastEnvelope<Actor = A>> {
+    fn priority(&self) -> Priority {
+        self.as_ref().priority()
+    }
+}
+
 pub struct BroadcastEnvelopeConcrete<A, M> {
     message: M,
-    priority: u32,
+    priority: spin::Mutex<u32>,
     phantom: PhantomData<for<'a> fn(&'a A)>,
     instrumentation: Instrumentation,
 }
@@ -214,7 +242,7 @@ impl<A: Actor, M> BroadcastEnvelopeConcrete<A, M> {
     pub fn new(message: M, priority: u32) -> Self {
         BroadcastEnvelopeConcrete {
             message,
-            priority,
+            priority: spin::Mutex::new(priority),
             phantom: PhantomData,
             instrumentation: Instrumentation::new::<A, M>(),
         }
@@ -227,6 +255,10 @@ where
     M: Clone + Send + Sync + 'static,
 {
     type Actor = A;
+
+    fn set_priority(&self, new_priority: u32) {
+        *self.priority.lock() = new_priority;
+    }
 
     fn handle<'a>(
         self: Arc<Self>,
@@ -246,7 +278,7 @@ where
 
 impl<A, M> HasPriority for BroadcastEnvelopeConcrete<A, M> {
     fn priority(&self) -> Priority {
-        Priority::Valued(self.priority)
+        Priority::Valued(*self.priority.lock())
     }
 }
 
@@ -279,6 +311,8 @@ where
     A: Actor,
 {
     type Actor = A;
+
+    fn set_priority(&self, _: u32) {}
 
     fn handle<'a>(
         self: Arc<Self>,

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -211,7 +211,9 @@ impl<A, Rc: TxRefCounter> SetPriority for SendFuture<A, Rc> {
     fn set_priority(&mut self, priority: u32) {
         match &mut self.inner {
             SendFutureInner::New(SentMessage::ToOneActor(ref mut m)) => m.set_priority(priority),
-            SendFutureInner::New(SentMessage::ToAllActors(ref mut m)) => m.set_priority(priority),
+            SendFutureInner::New(SentMessage::ToAllActors(ref mut m)) => Arc::get_mut(m)
+                .expect("envelope is not cloned until here")
+                .set_priority(priority),
             _ => panic!("setting priority after polling is unsupported"),
         }
     }

--- a/src/message_channel.rs
+++ b/src/message_channel.rs
@@ -8,7 +8,7 @@ use futures_sink::Sink;
 
 use crate::address::{ActorJoinHandle, Address};
 use crate::envelope::ReturningEnvelope;
-use crate::inbox::{PriorityMessageToOne, SentMessage};
+use crate::inbox::SentMessage;
 use crate::refcount::{Either, RefCounter, Strong, Weak};
 use crate::send_future::{ActorErasedSending, ResolveToHandlerReturn, SendFuture};
 use crate::{Error, Handler};
@@ -296,9 +296,8 @@ where
         &self,
         message: M,
     ) -> SendFuture<R, ActorErasedSending<Self::Return>, ResolveToHandlerReturn> {
-        let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message);
-        let msg = PriorityMessageToOne::new(0, Box::new(envelope));
-        let sending = self.0.send(SentMessage::ToOneActor(msg));
+        let (envelope, rx) = ReturningEnvelope::<A, M, R>::new(message, 0);
+        let sending = self.0.send(SentMessage::ToOneActor(Box::new(envelope)));
 
         SendFuture::sending_erased(sending, rx)
     }


### PR DESCRIPTION
Previously, we only stored the priority of broadcast messages in
the envelope. For regular messages, the priority was stored
outside in a wrapper struct.

This disparity is hard to understand as there is no apparent reason
why the priority could not be stored in the message envelope.

With this patch, we move the priority into the message envelope
and also expose a `set_priority` function for each envelope type
which allows us to consolidate the way we set priority from the
`SendFuture`.