### PR TITLE
Rename message -> message_type and use Display for strs

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -88,20 +88,20 @@ impl Instrumentation {
     }
 
     #[cfg_attr(not(feature = "instrumentation"), allow(unused_variables))]
-    fn started<A>(message: &'static str) -> Self {
+    fn started<A>(message_type: &'static str) -> Self {
         #[cfg(feature = "instrumentation")]
         {
             let parent = Span(tracing::debug_span!(
                 "xtra_actor_request",
-                actor = std::any::type_name::<A>(),
-                %message,
+                actor = %std::any::type_name::<A>(),
+                %message_type,
             ));
 
             let _waiting_for_actor = Span(tracing::debug_span!(
                 parent: &parent.0,
                 "xtra_message_waiting_for_actor",
-                actor = std::any::type_name::<A>(),
-                %message,
+                actor = %std::any::type_name::<A>(),
+                %message_type,
             ));
 
             Instrumentation {
@@ -123,8 +123,8 @@ impl Instrumentation {
             let executing = tracing::debug_span!(
                 parent: &self.parent.0,
                 "xtra_message_handler",
-                actor = std::any::type_name::<A>(),
-                message = std::any::type_name::<M>(),
+                actor = %std::any::type_name::<A>(),
+                message_type = %std::any::type_name::<M>(),
                 interrupted = tracing::field::Empty,
             );
 

--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -139,7 +139,11 @@ async fn assert_send_is_child_of_span() {
         assert_eq!(
             lines,
             [
-                r#" INFO user_span:xtra_actor_request{actor="instrumentation::Tracer" instrumentation::Hello}:xtra_message_handler{actor="instrumentation::Tracer" instrumentation::Hello}: instrumentation: Hello world"#
+                " INFO user_span:xtra_actor_request\
+                {actor=instrumentation::Tracer message_type=instrumentation::Hello}:\
+                xtra_message_handler\
+                {actor=instrumentation::Tracer message_type=instrumentation::Hello}: \
+                instrumentation: Hello world"
             ]
         );
     });


### PR DESCRIPTION
Weird behaviour is exhibited by some subscribers with `message` as a field name, probably since it is reserved, so `message_type` is used instead. Also, the display implementation of type name strings are used to avoid unnecessary quotes in the output.
