### PR TITLE
Strip span fields from waiting and handler spans

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -100,8 +100,6 @@ impl Instrumentation {
             let _waiting_for_actor = Span(tracing::debug_span!(
                 parent: &parent.0,
                 "xtra_message_waiting_for_actor",
-                actor_type = %std::any::type_name::<A>(),
-                %message_type,
             ));
 
             Instrumentation {
@@ -123,8 +121,6 @@ impl Instrumentation {
             let executing = tracing::debug_span!(
                 parent: &self.parent.0,
                 "xtra_message_handler",
-                actor_type = %std::any::type_name::<A>(),
-                message_type = %std::any::type_name::<M>(),
                 interrupted = tracing::field::Empty,
             );
 

--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -140,9 +140,7 @@ async fn assert_send_is_child_of_span() {
             lines,
             [" INFO user_span:xtra_actor_request\
                 {actor_type=instrumentation::Tracer message_type=instrumentation::Hello}:\
-                xtra_message_handler\
-                {actor_type=instrumentation::Tracer message_type=instrumentation::Hello}: \
-                instrumentation: Hello world"]
+                xtra_message_handler: instrumentation: Hello world"]
         );
     });
 }


### PR DESCRIPTION
Currently, these are always children of the request span, so adding them as fields in them too is redundant.

It would be a simplification to move this just to xtra_message_handler, but this is unfortunately not possible in the case of a disconnected actor which will never handle the message - this would miss all actor and message type information.