### PR TITLE
Don't pass message name into envelope

### DIFF
--- a/src/broadcast_future.rs
+++ b/src/broadcast_future.rs
@@ -39,7 +39,7 @@ where
         let envelope = BroadcastEnvelopeConcrete::<A, M>::new(message, 0);
 
         Self {
-            inner: sender.send(SentMessage::msg_to_all::<M>(Arc::new(envelope))),
+            inner: sender.send(SentMessage::ToAllActors(Arc::new(envelope))),
         }
     }
 

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -74,14 +74,14 @@ impl<A> Chan<A> {
 
         let mut inner = self.chan.lock().unwrap();
 
-        match message.msg {
-            MessageKind::ToAllActors(m) if !self.is_full(inner.broadcast_tail) => {
+        match message {
+            SentMessage::ToAllActors(m) if !self.is_full(inner.broadcast_tail) => {
                 inner.send_broadcast(m);
                 Ok(())
             }
-            MessageKind::ToAllActors(m) => {
+            SentMessage::ToAllActors(m) => {
                 // on_shutdown is only notified with inner locked, and it's locked here, so no race
-                let waiting = WaitingSender::new(MessageKind::ToAllActors(m));
+                let waiting = WaitingSender::new(SentMessage::ToAllActors(m));
                 inner.waiting_senders.push_back(Arc::downgrade(&waiting));
                 Err(TrySendFail::Full(waiting))
             }
@@ -324,7 +324,7 @@ impl<A> ChanInner<A> {
         // If len < cap after popping this message, try fulfill at most one waiting sender
         if capacity.map_or(false, |cap| cap == self.priority_queue.len()) {
             match self.try_fulfill_sender(MessageType::Priority) {
-                Some(MessageKind::ToOneActor(msg)) => self.priority_queue.push(ByPriority(msg)),
+                Some(SentMessage::ToOneActor(msg)) => self.priority_queue.push(ByPriority(msg)),
                 Some(_) => unreachable!(),
                 None => {}
             }
@@ -340,7 +340,7 @@ impl<A> ChanInner<A> {
         // If len < cap after popping this message, try fulfill at most one waiting sender
         if capacity.map_or(false, |cap| cap == self.ordered_queue.len()) {
             match self.try_fulfill_sender(MessageType::Ordered) {
-                Some(MessageKind::ToOneActor(msg)) => self.ordered_queue.push_back(msg),
+                Some(SentMessage::ToOneActor(msg)) => self.ordered_queue.push_back(msg),
                 Some(_) => unreachable!(),
                 None => {}
             }
@@ -362,7 +362,7 @@ impl<A> ChanInner<A> {
         // If len < cap, try fulfill a waiting sender
         if capacity.map_or(false, |cap| longest < cap) {
             match self.try_fulfill_sender(MessageType::Broadcast) {
-                Some(MessageKind::ToAllActors(m)) => self.send_broadcast(m),
+                Some(SentMessage::ToAllActors(m)) => self.send_broadcast(m),
                 Some(_) => unreachable!(),
                 None => {}
             }
@@ -399,7 +399,7 @@ impl<A> ChanInner<A> {
         Err(reason)
     }
 
-    fn try_fulfill_sender(&mut self, for_type: MessageType) -> Option<MessageKind<A>> {
+    fn try_fulfill_sender(&mut self, for_type: MessageType) -> Option<SentMessage<A>> {
         self.waiting_senders
             .retain(|tx| Weak::strong_count(tx) != 0);
 
@@ -408,7 +408,7 @@ impl<A> ChanInner<A> {
                 self.waiting_senders
                     .iter()
                     .position(|tx| match tx.upgrade() {
-                        Some(tx) => matches!(tx.lock().peek(), MessageKind::ToOneActor(m) if m.priority() == Priority::default()),
+                        Some(tx) => matches!(tx.lock().peek(), SentMessage::ToOneActor(m) if m.priority() == Priority::default()),
                         None => false,
                     })?
             } else {
@@ -417,13 +417,13 @@ impl<A> ChanInner<A> {
                     .enumerate()
                     .max_by_key(|(_idx, tx)| match tx.upgrade() {
                         Some(tx) => match tx.lock().peek() {
-                            MessageKind::ToOneActor(m)
+                            SentMessage::ToOneActor(m)
                                 if for_type == MessageType::Priority
                                     && m.priority() > Priority::default() =>
                             {
                                 Some(m.priority())
                             }
-                            MessageKind::ToAllActors(m) if for_type == MessageType::Broadcast => {
+                            SentMessage::ToAllActors(m) if for_type == MessageType::Broadcast => {
                                 Some(m.priority())
                             }
                             _ => None,
@@ -447,35 +447,19 @@ enum MessageType {
     Priority,
 }
 
-pub struct SentMessage<A> {
-    pub msg: MessageKind<A>,
-}
-
-pub enum MessageKind<A> {
+pub enum SentMessage<A> {
     ToOneActor(Box<dyn MessageEnvelope<Actor = A>>),
     ToAllActors(Arc<dyn BroadcastEnvelope<Actor = A>>),
 }
 
 impl<A> SentMessage<A> {
-    pub fn msg_to_one<M>(msg: Box<dyn MessageEnvelope<Actor = A>>) -> Self {
-        SentMessage {
-            msg: MessageKind::ToOneActor(msg),
-        }
-    }
-
-    pub fn msg_to_all<M>(msg: Arc<dyn BroadcastEnvelope<Actor = A>>) -> Self {
-        SentMessage {
-            msg: MessageKind::ToAllActors(msg),
-        }
-    }
-
     pub fn start_span(&mut self) {
         #[cfg(feature = "instrumentation")]
-        match &mut self.msg {
-            MessageKind::ToOneActor(m) => {
+        match self {
+            SentMessage::ToOneActor(m) => {
                 m.start_span();
             }
-            MessageKind::ToAllActors(m) => {
+            SentMessage::ToAllActors(m) => {
                 Arc::get_mut(m)
                     .expect("calling after try_send not supported")
                     .start_span();
@@ -484,18 +468,18 @@ impl<A> SentMessage<A> {
     }
 }
 
-impl<A> From<MessageKind<A>> for WakeReason<A> {
-    fn from(msg: MessageKind<A>) -> Self {
+impl<A> From<SentMessage<A>> for WakeReason<A> {
+    fn from(msg: SentMessage<A>) -> Self {
         match msg {
-            MessageKind::ToOneActor(m) => WakeReason::MessageToOneActor(m),
-            MessageKind::ToAllActors(_) => WakeReason::MessageToAllActors,
+            SentMessage::ToOneActor(m) => WakeReason::MessageToOneActor(m),
+            SentMessage::ToAllActors(_) => WakeReason::MessageToAllActors,
         }
     }
 }
 
-impl<A> From<Box<dyn MessageEnvelope<Actor = A>>> for MessageKind<A> {
+impl<A> From<Box<dyn MessageEnvelope<Actor = A>>> for SentMessage<A> {
     fn from(msg: Box<dyn MessageEnvelope<Actor = A>>) -> Self {
-        MessageKind::ToOneActor(msg)
+        SentMessage::ToOneActor(msg)
     }
 }
 

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -448,8 +448,6 @@ enum MessageType {
 }
 
 pub struct SentMessage<A> {
-    #[cfg(feature = "instrumentation")]
-    msg_type: &'static str,
     pub msg: MessageKind<A>,
 }
 
@@ -461,16 +459,12 @@ pub enum MessageKind<A> {
 impl<A> SentMessage<A> {
     pub fn msg_to_one<M>(msg: Box<dyn MessageEnvelope<Actor = A>>) -> Self {
         SentMessage {
-            #[cfg(feature = "instrumentation")]
-            msg_type: std::any::type_name::<M>(),
             msg: MessageKind::ToOneActor(msg),
         }
     }
 
     pub fn msg_to_all<M>(msg: Arc<dyn BroadcastEnvelope<Actor = A>>) -> Self {
         SentMessage {
-            #[cfg(feature = "instrumentation")]
-            msg_type: std::any::type_name::<M>(),
             msg: MessageKind::ToAllActors(msg),
         }
     }
@@ -479,12 +473,12 @@ impl<A> SentMessage<A> {
         #[cfg(feature = "instrumentation")]
         match &mut self.msg {
             MessageKind::ToOneActor(m) => {
-                m.start_span(self.msg_type);
+                m.start_span();
             }
             MessageKind::ToAllActors(m) => {
                 Arc::get_mut(m)
                     .expect("calling after try_send not supported")
-                    .start_span(self.msg_type);
+                    .start_span();
             }
         };
     }

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -100,7 +100,7 @@ impl<R> SendFuture<R, ActorErasedSending<R>, ResolveToHandlerReturn> {
 
         Self {
             inner: SendFutureInner::Sending(ActorErasedSending {
-                future: Box::new(sender.send(SentMessage::msg_to_one::<M>(Box::new(envelope)))),
+                future: Box::new(sender.send(SentMessage::ToOneActor(Box::new(envelope)))),
                 rx: Some(rx),
             }),
             phantom: PhantomData,
@@ -122,7 +122,7 @@ impl<A, R, Rc: RefCounter> SendFuture<R, NameableSending<A, R, Rc>, ResolveToHan
 
         Self {
             inner: SendFutureInner::Sending(NameableSending {
-                inner: sender.send(SentMessage::msg_to_one::<M>(Box::new(envelope))),
+                inner: sender.send(SentMessage::ToOneActor(Box::new(envelope))),
                 receiver: Some(Receiver::new(rx)),
             }),
             phantom: PhantomData,


### PR DESCRIPTION
An envelope knows which message it is carrying, no need to pass
it in.