### PR TITLE
Use or_current when creating spans

### DIFF
--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -170,7 +170,9 @@ async fn assert_handler_span_is_child_of_caller_span_with_min_level_info() {
         .await;
 
     with_logs(&buf, |lines: &[&str]| {
-        assert_eq!(lines, [" INFO sender_span:info_span: instrumentation: Test!"]);
+        assert_eq!(
+            lines,
+            [" INFO sender_span:info_span: instrumentation: Test!"]
+        );
     });
 }
-


### PR DESCRIPTION
This makes sure that if the xtra_actor_request is disabled, the other spans and child-spans of xtra_message_handler will be children of the would-be parent of xtra_actor_request, rather than being parentless, top-level spans.