### PR TITLE
Remove generic ref-counting from `Receiver`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,7 @@ use futures_util::future::{self, Either};
 use futures_util::FutureExt;
 
 use crate::envelope::{Shutdown, Span};
-use crate::inbox::rx::{ReceiveFuture as InboxReceiveFuture, RxStrong};
+use crate::inbox::rx::ReceiveFuture as InboxReceiveFuture;
 use crate::inbox::ActorMessage;
 use crate::{inbox, Actor, Address, Error, WeakAddress};
 
@@ -27,7 +27,7 @@ pub struct Context<A> {
     /// to achieve this.
     pub running: bool,
     /// The actor's mailbox.
-    mailbox: inbox::Receiver<A, RxStrong>,
+    mailbox: inbox::Receiver<A>,
 }
 
 impl<A: Actor> Context<A> {
@@ -331,7 +331,7 @@ pub struct Message<A>(pub(crate) ActorMessage<A>);
 /// poll on the future. [`ReceiveFuture`] is guaranteed to complete in a single poll if it has
 /// remaining work to do.
 #[must_use = "Futures do nothing unless polled"]
-pub struct ReceiveFuture<A>(InboxReceiveFuture<A, RxStrong>);
+pub struct ReceiveFuture<A>(InboxReceiveFuture<A>);
 
 impl<A> Future for ReceiveFuture<A> {
     type Output = Message<A>;

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -19,7 +19,6 @@ pub use rx::Receiver;
 pub use tx::Sender;
 
 use crate::envelope::{BroadcastEnvelope, MessageEnvelope, Shutdown};
-use crate::inbox::rx::RxStrong;
 use crate::inbox::tx::TxStrong;
 use crate::inbox::waiting_receiver::{FulfillHandle, WaitingReceiver};
 use crate::{Actor, Error};
@@ -29,7 +28,7 @@ type BroadcastQueue<A> = Spinlock<BinaryHeap<ByPriority<Arc<dyn BroadcastEnvelop
 
 /// Create an actor mailbox, returning a sender and receiver for it. The given capacity is applied
 /// severally to each send type - priority, ordered, and broadcast.
-pub fn new<A>(capacity: Option<usize>) -> (Sender<A, TxStrong>, Receiver<A, RxStrong>) {
+pub fn new<A>(capacity: Option<usize>) -> (Sender<A, TxStrong>, Receiver<A>) {
     let inner = Arc::new(Chan::new(capacity));
 
     let tx = Sender::new(inner.clone());

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -67,9 +67,7 @@ impl<A> Clone for Receiver<A> {
 
 impl<A> Drop for Receiver<A> {
     fn drop(&mut self) {
-        if self.inner.decrement_receiver_count() {
-            self.inner.shutdown_waiting_senders()
-        }
+        self.inner.decrement_receiver_count()
     }
 }
 

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -12,19 +12,19 @@ use crate::inbox::tx::{TxStrong, TxWeak};
 use crate::inbox::waiting_receiver::WaitingReceiver;
 use crate::inbox::{ActorMessage, BroadcastQueue, Chan, Sender};
 
-pub struct Receiver<A, Rc: RxRefCounter> {
+pub struct Receiver<A> {
     inner: Arc<Chan<A>>,
     broadcast_mailbox: Arc<BroadcastQueue<A>>,
-    rc: Rc,
+    rc: RxStrong,
 }
 
-impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
+impl<A> Receiver<A> {
     pub fn next_broadcast_message(&self) -> Option<Arc<dyn BroadcastEnvelope<Actor = A>>> {
         self.inner.pop_broadcast_message(&self.broadcast_mailbox)
     }
 }
 
-impl<A> Receiver<A, RxStrong> {
+impl<A> Receiver<A> {
     pub(super) fn new(inner: Arc<Chan<A>>) -> Self {
         let rc = RxStrong(());
         rc.increment(&inner);
@@ -37,7 +37,7 @@ impl<A> Receiver<A, RxStrong> {
     }
 }
 
-impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
+impl<A> Receiver<A> {
     pub fn sender(&self) -> Option<Sender<A, TxStrong>> {
         Sender::try_new_strong(self.inner.clone())
     }
@@ -46,7 +46,7 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
         Sender::new_weak(self.inner.clone())
     }
 
-    pub fn receive(&self) -> ReceiveFuture<A, Rc> {
+    pub fn receive(&self) -> ReceiveFuture<A> {
         let receiver_with_same_broadcast_mailbox = Receiver {
             inner: self.inner.clone(),
             broadcast_mailbox: self.broadcast_mailbox.clone(),
@@ -57,7 +57,7 @@ impl<A, Rc: RxRefCounter> Receiver<A, Rc> {
     }
 }
 
-impl<A, Rc: RxRefCounter> Clone for Receiver<A, Rc> {
+impl<A> Clone for Receiver<A> {
     fn clone(&self) -> Self {
         Receiver {
             inner: self.inner.clone(),
@@ -67,7 +67,7 @@ impl<A, Rc: RxRefCounter> Clone for Receiver<A, Rc> {
     }
 }
 
-impl<A, Rc: RxRefCounter> Drop for Receiver<A, Rc> {
+impl<A> Drop for Receiver<A> {
     fn drop(&mut self) {
         if self.rc.decrement(&self.inner) {
             self.inner.shutdown_waiting_senders()
@@ -75,9 +75,9 @@ impl<A, Rc: RxRefCounter> Drop for Receiver<A, Rc> {
     }
 }
 
-pub enum ReceiveFuture<A, Rc: RxRefCounter> {
-    New(Receiver<A, Rc>),
-    Waiting(Waiting<A, Rc>),
+pub enum ReceiveFuture<A> {
+    New(Receiver<A>),
+    Waiting(Waiting<A>),
     Done,
 }
 
@@ -88,19 +88,13 @@ pub enum ReceiveFuture<A, Rc: RxRefCounter> {
 ///
 /// To avoid losing a message, this type implements [`Drop`] and re-queues the message into the
 /// mailbox in such a scenario.
-pub struct Waiting<A, Rc>
-where
-    Rc: RxRefCounter,
-{
-    channel_receiver: Receiver<A, Rc>,
+pub struct Waiting<A> {
+    channel_receiver: Receiver<A>,
     waiting_receiver: WaitingReceiver<A>,
 }
 
-impl<A, Rc> Future for Waiting<A, Rc>
-where
-    Rc: RxRefCounter,
-{
-    type Output = Result<ActorMessage<A>, Receiver<A, Rc>>;
+impl<A> Future for Waiting<A> {
+    type Output = Result<ActorMessage<A>, Receiver<A>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -115,10 +109,7 @@ where
     }
 }
 
-impl<A, Rc> Drop for Waiting<A, Rc>
-where
-    Rc: RxRefCounter,
-{
+impl<A> Drop for Waiting<A> {
     fn drop(&mut self) {
         if let Some(msg) = self.waiting_receiver.cancel() {
             self.channel_receiver.inner.requeue_message(msg);
@@ -126,7 +117,7 @@ where
     }
 }
 
-impl<A, Rc: RxRefCounter> Future for ReceiveFuture<A, Rc> {
+impl<A> Future for ReceiveFuture<A> {
     type Output = ActorMessage<A>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ActorMessage<A>> {
@@ -160,7 +151,7 @@ impl<A, Rc: RxRefCounter> Future for ReceiveFuture<A, Rc> {
     }
 }
 
-impl<A, Rc: RxRefCounter> FusedFuture for ReceiveFuture<A, Rc> {
+impl<A> FusedFuture for ReceiveFuture<A> {
     fn is_terminated(&self) -> bool {
         matches!(self, ReceiveFuture::Done)
     }
@@ -188,17 +179,5 @@ impl RxRefCounter for RxStrong {
 
         atomic::fence(atomic::Ordering::Acquire);
         true
-    }
-}
-
-pub struct RxWeak(());
-
-impl RxRefCounter for RxWeak {
-    fn increment<A>(&self, _inner: &Chan<A>) -> Self {
-        RxWeak(())
-    }
-
-    fn decrement<A>(&self, _inner: &Chan<A>) -> bool {
-        false
     }
 }

--- a/src/inbox/waiting_receiver.rs
+++ b/src/inbox/waiting_receiver.rs
@@ -4,7 +4,6 @@ use futures_util::FutureExt;
 
 use crate::envelope::MessageEnvelope;
 use crate::inbox::rx::Receiver;
-use crate::inbox::rx::RxRefCounter;
 use crate::inbox::ActorMessage;
 
 /// A [`WaitingReceiver`] is handed out by the channel any time [`Chan::try_recv`](crate::inbox::Chan::try_recv) is called on an empty mailbox.
@@ -78,14 +77,11 @@ impl<A> WaitingReceiver<A> {
     /// In case we have been woken with a reason, we will attempt to produce an [`ActorMessage`].
     /// Wake-ups can be false-positives in the case of a broadcast message which is why this
     /// function returns only [`Option<ActorMessage>`].
-    pub fn poll<Rc>(
+    pub fn poll(
         &mut self,
-        receiver: &Receiver<A, Rc>,
+        receiver: &Receiver<A>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<ActorMessage<A>>>
-    where
-        Rc: RxRefCounter,
-    {
+    ) -> Poll<Option<ActorMessage<A>>> {
         let ctrl_msg = match futures_util::ready!(self.0.poll_unpin(cx)) {
             Ok(reason) => reason,
             Err(_) => return Poll::Ready(None), // TODO: Not sure if this is correct.


### PR DESCRIPTION
We never use weak references to mailboxes and don't expose a way for the user to construct one. Hence, the concept of generic reference counting is not useful here and only adds complexity.