### PR TITLE
Have `Sender` deref to `Chan`

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -186,7 +186,7 @@ impl<A, Rc: RefCounter> Address<A, Rc> {
     /// address, it will only ever trigger if the actor calls [`Context::stop_self`](crate::Context::stop_self),
     /// as the address would prevent the actor being dropped due to too few strong addresses.
     pub fn join(&self) -> ActorJoinHandle {
-        ActorJoinHandle(self.0.disconnect_notice())
+        ActorJoinHandle(self.0.disconnect_listener())
     }
 
     /// Returns true if this address and the other address point to the same actor. This is

--- a/src/context.rs
+++ b/src/context.rs
@@ -83,7 +83,7 @@ impl<A: Actor> Context<A> {
     pub fn stop_all(&mut self) {
         // We only need to shut down if there are still any strong senders left
         if let Some(sender) = self.mailbox.sender() {
-            sender.stop_all_receivers();
+            sender.shutdown_all_receivers();
         }
     }
 

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -180,17 +180,17 @@ impl<A> Chan<A> {
         }
     }
 
-    fn is_connected(&self) -> bool {
+    pub fn is_connected(&self) -> bool {
         self.receiver_count.load(atomic::Ordering::SeqCst) > 0
             && self.sender_count.load(atomic::Ordering::SeqCst) > 0
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         let inner = self.chan.lock().unwrap();
         inner.broadcast_tail + inner.ordered_queue.len() + inner.priority_queue.len()
     }
 
-    fn capacity(&self) -> Option<usize> {
+    pub fn capacity(&self) -> Option<usize> {
         self.chan.lock().unwrap().capacity
     }
 
@@ -214,7 +214,7 @@ impl<A> Chan<A> {
         }
     }
 
-    fn shutdown_all_receivers(&self)
+    pub fn shutdown_all_receivers(&self)
     where
         A: Actor,
     {
@@ -247,7 +247,7 @@ impl<A> Chan<A> {
         }
     }
 
-    fn disconnect_listener(&self) -> Option<EventListener> {
+    pub fn disconnect_listener(&self) -> Option<EventListener> {
         // Listener is created before checking connectivity to avoid the following race scenario:
         //
         // 1. is_connected returns true

--- a/src/send_future.rs
+++ b/src/send_future.rs
@@ -183,7 +183,7 @@ where
 
         loop {
             match mem::replace(this, Sending::Done) {
-                Sending::New { msg, sender } => match sender.inner.try_send(msg)? {
+                Sending::New { msg, sender } => match sender.try_send(msg)? {
                     Ok(()) => return Poll::Ready(Ok(())),
                     Err(MailboxFull(waiting)) => {
                         *this = Sending::WaitingToSend(waiting);


### PR DESCRIPTION
Essentially, `Sender` is a smart-pointer to `Chan` with custom reference
counting logic and thus it makes sense for it to implement `Deref`.
Most of the functionality accessed by other modules lives on `Chan`.