### PR TITLE
Encapsulate reference counting logic on `Chan`

### DIFF
--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -55,11 +55,13 @@ impl<A> Chan<A> {
         }
     }
 
-    pub fn increment_receiver_count(&self) {
+    /// Callback to be invoked every time a receiver is created.
+    pub fn on_receiver_created(&self) {
         self.receiver_count.fetch_add(1, atomic::Ordering::Relaxed);
     }
 
-    pub fn decrement_receiver_count(&self) {
+    /// Callback to be invoked every time a receiver is destroyed.
+    pub fn on_receiver_dropped(&self) {
         // Memory orderings copied from Arc::drop
         if self.receiver_count.fetch_sub(1, atomic::Ordering::Release) != 1 {
             return;
@@ -70,12 +72,14 @@ impl<A> Chan<A> {
         self.shutdown_waiting_senders();
     }
 
-    pub fn increment_sender_count(&self) {
+    /// Callback to be invoked every time a sender is created.
+    pub fn on_sender_created(&self) {
         // Memory orderings copied from Arc::clone
         self.sender_count.fetch_add(1, atomic::Ordering::Relaxed);
     }
 
-    pub fn decrement_sender_count(&self) {
+    /// Callback to be invoked every time a sender is destroyed (i.e. dropped).
+    pub fn on_sender_dropped(&self) {
         // Memory orderings copied from Arc::drop
         if self.sender_count.fetch_sub(1, atomic::Ordering::Release) != 1 {
             return;

--- a/src/inbox/rx.rs
+++ b/src/inbox/rx.rs
@@ -29,7 +29,7 @@ impl<A> Receiver<A> {
 
 impl<A> Receiver<A> {
     pub(super) fn new(inner: Arc<Chan<A>>) -> Self {
-        inner.increment_receiver_count();
+        inner.on_receiver_created();
 
         Receiver {
             broadcast_mailbox: inner.new_broadcast_mailbox(),
@@ -52,7 +52,7 @@ impl<A> Receiver<A> {
             inner: self.inner.clone(),
             broadcast_mailbox: self.broadcast_mailbox.clone(),
         };
-        self.inner.increment_receiver_count();
+        self.inner.on_receiver_created();
 
         ReceiveFuture::New(receiver_with_same_broadcast_mailbox)
     }
@@ -60,7 +60,7 @@ impl<A> Receiver<A> {
 
 impl<A> Clone for Receiver<A> {
     fn clone(&self) -> Self {
-        self.inner.increment_receiver_count();
+        self.inner.on_receiver_created();
 
         Receiver {
             inner: self.inner.clone(),
@@ -71,7 +71,7 @@ impl<A> Clone for Receiver<A> {
 
 impl<A> Drop for Receiver<A> {
     fn drop(&mut self) {
-        self.inner.decrement_receiver_count()
+        self.inner.on_receiver_dropped()
     }
 }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -225,6 +225,7 @@ mod private {
         fn into_either(self) -> TxEither {
             TxEither::Weak(self)
         }
+
         fn is_strong(&self) -> bool {
             false
         }
@@ -234,7 +235,7 @@ mod private {
         fn make_new<A>(&self, inner: &Chan<A>) -> Self {
             match self {
                 TxEither::Strong(strong) => TxEither::Strong(strong.make_new(inner)),
-                TxEither::Weak(weak) => TxEither::Weak(weak.new(inner)),
+                TxEither::Weak(weak) => TxEither::Weak(weak.make_new(inner)),
             }
         }
 

--- a/src/inbox/tx.rs
+++ b/src/inbox/tx.rs
@@ -194,13 +194,13 @@ mod private {
 
     impl RefCounterInner for TxStrong {
         fn increment<A>(&self, inner: &Chan<A>) -> Self {
-            inner.increment_sender_count();
+            inner.on_sender_created();
 
             TxStrong(())
         }
 
         fn decrement<A>(&self, inner: &Chan<A>) {
-            inner.decrement_sender_count();
+            inner.on_sender_dropped();
         }
 
         fn into_either(self) -> TxEither {


### PR DESCRIPTION
This follows the 'Tell, don't ask'-principle. Instead of first
decrementing the count on `Chan` and acting on it being a certain
value, we _delegate_ the decrementing to `Chan` and have it perform
the correct logic when necessary. This simplifies calling sites.