### PR TITLE
Refactor instrumentation tests

### DIFF
--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -106,13 +106,13 @@ impl Handler<CreateInfoSpan> for Tracer {
 }
 
 #[derive(Debug)]
-pub struct MockWriter {
+struct MockWriter {
     buf: Arc<Mutex<Vec<u8>>>,
 }
 
 impl MockWriter {
     /// Create a new `MockWriter` that writes into the specified buffer (behind a mutex).
-    pub fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+    fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
         Self { buf }
     }
 
@@ -154,7 +154,7 @@ impl MakeWriter<'_> for MockWriter {
 /// Return a new subscriber that writes to the specified [`MockWriter`].
 ///
 /// [`MockWriter`]: struct.MockWriter.html
-pub fn get_subscriber(mock_writer: MockWriter, env_filter: &str) -> Dispatch {
+fn get_subscriber(mock_writer: MockWriter, env_filter: &str) -> Dispatch {
     FmtSubscriber::builder()
         .with_env_filter(env_filter)
         .with_writer(mock_writer)
@@ -164,7 +164,7 @@ pub fn get_subscriber(mock_writer: MockWriter, env_filter: &str) -> Dispatch {
         .into()
 }
 
-pub fn with_logs<F>(buf: &Mutex<Vec<u8>>, f: F)
+fn with_logs<F>(buf: &Mutex<Vec<u8>>, f: F)
 where
     F: Fn(&[&str]),
 {

--- a/tests/instrumentation.rs
+++ b/tests/instrumentation.rs
@@ -31,6 +31,80 @@ use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::FmtSubscriber;
 use xtra::prelude::*;
 
+#[tokio::test]
+async fn assert_send_is_child_of_span() {
+    let buf = Arc::new(Mutex::new(vec![]));
+    let mock_writer = MockWriter::new(buf.clone());
+    let subscriber = get_subscriber(mock_writer, "instrumentation=trace,xtra=trace");
+    let _g = tracing::dispatcher::set_default(&subscriber);
+
+    let addr = xtra::spawn_tokio(Tracer, None);
+    let _ = addr
+        .send(Hello("world"))
+        .instrument(tracing::info_span!("user_span"))
+        .await;
+
+    with_logs(&buf, |lines: &[&str]| {
+        assert_eq!(
+            lines,
+            [" INFO user_span:xtra_actor_request\
+                {actor_type=instrumentation::Tracer message_type=instrumentation::Hello}:\
+                xtra_message_handler: instrumentation: Hello world"]
+        );
+    });
+}
+
+#[tokio::test]
+async fn assert_handler_span_is_child_of_caller_span_with_min_level_info() {
+    let buf = Arc::new(Mutex::new(vec![]));
+    let mock_writer = MockWriter::new(buf.clone());
+    let subscriber = get_subscriber(mock_writer, "instrumentation=info,xtra=info");
+    let _g = tracing::dispatcher::set_default(&subscriber);
+
+    let addr = xtra::spawn_tokio(Tracer, None);
+    let _ = addr
+        .send(CreateInfoSpan)
+        .instrument(tracing::info_span!("sender_span"))
+        .await;
+
+    with_logs(&buf, |lines: &[&str]| {
+        assert_eq!(
+            lines,
+            [" INFO sender_span:info_span: instrumentation: Test!"]
+        );
+    });
+}
+
+struct Tracer;
+
+#[async_trait]
+impl Actor for Tracer {
+    type Stop = ();
+    async fn stopped(self) {}
+}
+
+struct Hello(&'static str);
+
+#[async_trait]
+impl Handler<Hello> for Tracer {
+    type Return = ();
+
+    async fn handle(&mut self, message: Hello, _ctx: &mut Context<Self>) {
+        tracing::info!("Hello {}", message.0)
+    }
+}
+
+struct CreateInfoSpan;
+
+#[async_trait]
+impl Handler<CreateInfoSpan> for Tracer {
+    type Return = ();
+
+    async fn handle(&mut self, _msg: CreateInfoSpan, _ctx: &mut Context<Self>) {
+        tracing::info_span!("info_span").in_scope(|| tracing::info!("Test!"));
+    }
+}
+
 #[derive(Debug)]
 pub struct MockWriter {
     buf: Arc<Mutex<Vec<u8>>>,
@@ -100,78 +174,4 @@ where
         .lines()
         .collect();
     f(&logs)
-}
-
-struct Tracer;
-
-#[async_trait]
-impl Actor for Tracer {
-    type Stop = ();
-    async fn stopped(self) {}
-}
-
-struct Hello(&'static str);
-
-#[async_trait]
-impl Handler<Hello> for Tracer {
-    type Return = ();
-
-    async fn handle(&mut self, message: Hello, _ctx: &mut Context<Self>) {
-        tracing::info!("Hello {}", message.0)
-    }
-}
-
-struct CreateInfoSpan;
-
-#[async_trait]
-impl Handler<CreateInfoSpan> for Tracer {
-    type Return = ();
-
-    async fn handle(&mut self, _msg: CreateInfoSpan, _ctx: &mut Context<Self>) {
-        tracing::info_span!("info_span").in_scope(|| tracing::info!("Test!"));
-    }
-}
-
-#[tokio::test]
-async fn assert_send_is_child_of_span() {
-    let buf = Arc::new(Mutex::new(vec![]));
-    let mock_writer = MockWriter::new(buf.clone());
-    let subscriber = get_subscriber(mock_writer, "instrumentation=trace,xtra=trace");
-    let _g = tracing::dispatcher::set_default(&subscriber);
-
-    let addr = xtra::spawn_tokio(Tracer, None);
-    let _ = addr
-        .send(Hello("world"))
-        .instrument(tracing::info_span!("user_span"))
-        .await;
-
-    with_logs(&buf, |lines: &[&str]| {
-        assert_eq!(
-            lines,
-            [" INFO user_span:xtra_actor_request\
-                {actor_type=instrumentation::Tracer message_type=instrumentation::Hello}:\
-                xtra_message_handler: instrumentation: Hello world"]
-        );
-    });
-}
-
-#[tokio::test]
-async fn assert_handler_span_is_child_of_caller_span_with_min_level_info() {
-    let buf = Arc::new(Mutex::new(vec![]));
-    let mock_writer = MockWriter::new(buf.clone());
-    let subscriber = get_subscriber(mock_writer, "instrumentation=info,xtra=info");
-    let _g = tracing::dispatcher::set_default(&subscriber);
-
-    let addr = xtra::spawn_tokio(Tracer, None);
-    let _ = addr
-        .send(CreateInfoSpan)
-        .instrument(tracing::info_span!("sender_span"))
-        .await;
-
-    with_logs(&buf, |lines: &[&str]| {
-        assert_eq!(
-            lines,
-            [" INFO sender_span:info_span: instrumentation: Test!"]
-        );
-    });
 }


### PR DESCRIPTION
The elements in the file are now ordered by priority (tests come first) and the implementation of the tracing harness is tidied up to reduce duplication between the tests.