### PR TITLE
Simplify conditional code around instrumentation feature

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -10,9 +10,10 @@ use futures_core::FusedFuture;
 use futures_util::future::{self, Either};
 use futures_util::FutureExt;
 
-use crate::envelope::{Shutdown, Span};
+use crate::envelope::Shutdown;
 use crate::inbox::rx::ReceiveFuture as InboxReceiveFuture;
 use crate::inbox::ActorMessage;
+use crate::instrumentation::Span;
 use crate::{inbox, Actor, Address, Error, WeakAddress};
 
 /// `Context` is used to control how the actor is managed and to get the actor's address from inside
@@ -390,17 +391,14 @@ impl<'a, A> TickFuture<'a, A> {
     /// ```
     ///
     #[cfg(feature = "instrumentation")]
-    pub fn get_or_create_span(&mut self) -> &tracing::Span {
-        let span = mem::replace(&mut self.span.0, tracing::Span::none());
+    pub fn get_or_create_span(&mut self) -> &Span {
+        let span = mem::replace(&mut self.span, Span::none());
         *self = match mem::replace(&mut self.state, TickState::Done) {
             TickState::New { msg, act, ctx } => TickFuture::running(msg, act, ctx),
-            state => TickFuture {
-                state,
-                span: Span(span),
-            },
+            state => TickFuture { state, span },
         };
 
-        &self.span.0
+        &self.span
     }
 
     fn running(msg: ActorMessage<A>, act: &'a mut A, ctx: &'a mut Context<A>) -> TickFuture<'a, A> {
@@ -437,10 +435,7 @@ impl<'a, A> TickFuture<'a, A> {
     fn new(msg: ActorMessage<A>, act: &'a mut A, ctx: &'a mut Context<A>) -> Self {
         TickFuture {
             state: TickState::New { msg, act, ctx },
-            span: Span(
-                #[cfg(feature = "instrumentation")]
-                tracing::Span::none(),
-            ),
+            span: Span::none(),
         }
     }
 }

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "instrumentation")]
+mod tracing;
+
+#[cfg(feature = "instrumentation")]
+pub use self::tracing::*;
+
+#[cfg(not(feature = "instrumentation"))]
+mod stub;
+
+#[cfg(not(feature = "instrumentation"))]
+pub use self::stub::*;

--- a/src/instrumentation/stub.rs
+++ b/src/instrumentation/stub.rs
@@ -1,0 +1,42 @@
+use std::future::Future;
+
+#[derive(Clone)]
+pub struct Instrumentation {}
+
+#[derive(Clone)]
+pub struct Span(());
+
+impl Span {
+    pub fn in_scope<R>(&self, f: impl FnOnce() -> R) -> R {
+        f()
+    }
+
+    pub fn none() -> Span {
+        Span(())
+    }
+
+    pub fn is_none(&self) -> bool {
+        true
+    }
+}
+
+impl Instrumentation {
+    pub fn empty() -> Self {
+        Instrumentation {}
+    }
+
+    pub fn started<A, M>() -> Self {
+        Self::empty()
+    }
+
+    pub fn is_parent_none(&self) -> bool {
+        true
+    }
+
+    pub fn apply<A, M, F>(self, fut: F) -> (impl Future<Output = F::Output>, Span)
+    where
+        F: Future,
+    {
+        (fut, Span(()))
+    }
+}

--- a/src/instrumentation/tracing.rs
+++ b/src/instrumentation/tracing.rs
@@ -1,0 +1,54 @@
+use std::future::Future;
+
+pub use tracing::Span;
+
+#[derive(Clone)]
+pub struct Instrumentation {
+    pub parent: Span,
+    _waiting_for_actor: Span,
+}
+
+impl Instrumentation {
+    pub fn empty() -> Self {
+        Instrumentation {
+            parent: Span::none(),
+            _waiting_for_actor: Span::none(),
+        }
+    }
+
+    pub fn started<A, M>() -> Self {
+        let parent = tracing::debug_span!(
+            "xtra_actor_request",
+            actor_type = %std::any::type_name::<A>(),
+            message_type = %std::any::type_name::<M>(),
+        )
+        .or_current();
+
+        let _waiting_for_actor =
+            tracing::debug_span!(parent: &parent, "xtra_message_waiting_for_actor",).or_current();
+
+        Instrumentation {
+            parent,
+            _waiting_for_actor,
+        }
+    }
+
+    pub fn is_parent_none(&self) -> bool {
+        self.parent.is_none()
+    }
+
+    pub fn apply<A, M, F>(self, fut: F) -> (impl Future<Output = F::Output>, Span)
+    where
+        F: Future,
+    {
+        let executing = self.parent.in_scope(|| {
+            tracing::debug_span!("xtra_message_handler", interrupted = tracing::field::Empty)
+                .or_current()
+        });
+
+        (
+            tracing::Instrument::instrument(fut, executing.clone()),
+            executing,
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod address;
 mod context;
 mod envelope;
 mod inbox;
+mod instrumentation;
 pub mod message_channel;
 /// This module contains a way to scope a future to the lifetime of an actor, stopping it before it
 /// completes if the actor it is associated with stops too.


### PR DESCRIPTION
By splitting things into modules with identical APIs, we can remove a lot of `cfg(feature)` attributes.