### PR TITLE
Enforce grouping of imports per module

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
-custom-fmt = "fmt -- --config group_imports=StdExternalCrate"
-check-custom-fmt = "fmt -- --check --config group_imports=StdExternalCrate"
+custom-fmt = "fmt -- --config group_imports=StdExternalCrate --config imports_granularity=module"
+check-custom-fmt = "fmt -- --check --config group_imports=StdExternalCrate --config imports_granularity=module"

--- a/examples/basic_wasm_bindgen/src/lib.rs
+++ b/examples/basic_wasm_bindgen/src/lib.rs
@@ -1,4 +1,5 @@
-use wasm_bindgen::{prelude::*, JsValue};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
 use xtra::prelude::*;
 
 struct Echoer;

--- a/examples/crude_bench.rs
+++ b/examples/crude_bench.rs
@@ -4,8 +4,7 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use xtra::prelude::*;
 use xtra::refcount::Strong;
-use xtra::SendFuture;
-use xtra::{ActorErasedSending, ActorNamedSending};
+use xtra::{ActorErasedSending, ActorNamedSending, SendFuture};
 
 struct Counter {
     count: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,9 @@ pub mod prelude {
 /// This module contains types representing the strength of an address's reference counting, which
 /// influences whether the address will keep the actor alive for as long as it lives.
 pub mod refcount {
-    pub use crate::inbox::tx::TxEither as Either;
-    pub use crate::inbox::tx::TxRefCounter as RefCounter;
-    pub use crate::inbox::tx::TxStrong as Strong;
-    pub use crate::inbox::tx::TxWeak as Weak;
+    pub use crate::inbox::tx::{
+        TxEither as Either, TxRefCounter as RefCounter, TxStrong as Strong, TxWeak as Weak,
+    };
 }
 
 /// Provides a default implementation of the [`Actor`] trait for the given type with a [`Stop`](Actor::Stop) type of `()` and empty lifecycle functions.


### PR DESCRIPTION
Most of our codebase seems to be formatted this way, we can enforce
this with a rustfmt setting.