### PR TITLE
Fix `scoped_actor_task` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ required-features = ["tokio", "tokio/full"]
 
 [[example]]
 name = "scoped_actor_task"
-required-features = ["tokio", "futures-util/default"]
+required-features = ["tokio"]
 
 [[example]]
 name = "custom_event_loop"

--- a/examples/scoped_actor_task.rs
+++ b/examples/scoped_actor_task.rs
@@ -1,6 +1,5 @@
 use futures_util::future;
 use xtra::prelude::*;
-use xtra::spawn::Tokio;
 
 struct MyActor;
 
@@ -32,7 +31,7 @@ impl Drop for DropChecker {
 
 #[tokio::main]
 async fn main() {
-    let addr = MyActor.create(None).spawn(&mut Tokio::Global);
+    let addr = xtra::spawn_tokio(MyActor, None);
     addr.send(Print("hello".to_string()))
         .await
         .expect("Actor should not be dropped");


### PR DESCRIPTION
Because of an unknown feature, this example was not compiled as
part of our CI run and we missed it while moving to the new spawn
API.