### PR TITLE
Rework tests around drop behaviour of actors

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -161,7 +161,7 @@ async fn actor_stops_on_last_drop_of_address_even_if_not_yet_running() {
 }
 
 #[tokio::test]
-async fn actor_stops_on_stop_message_even_if_send_before_started() {
+async fn actor_stops_on_stop_message_even_if_sent_before_started() {
     let (addr, context) = Context::new(None);
     let weak = addr.downgrade();
     let join = weak.join();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -161,7 +161,7 @@ async fn actor_stops_on_last_drop_of_address_even_if_not_yet_running() {
 }
 
 #[tokio::test]
-async fn actor_stops_on_stop_message_even_if_not_yet_running() {
+async fn actor_stops_on_stop_message_even_if_send_before_started() {
     let (addr, context) = Context::new(None);
     let weak = addr.downgrade();
     let join = weak.join();


### PR DESCRIPTION
Previously, xtra's Actor had different behaviour depending on whether the last `Address` was dropped, `Context::stop` was called or `Context::stop_self` was called.

With the removal of `Actor::stopping` and the simplification of the event loop, these behaviours have been unified. Prior to this patch, the tests written for these cases were a bit outdated.

We simplify these tests and split them into individual ones.