### PR TITLE
Remove rx/tx terminology from Debug output

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -67,7 +67,15 @@ pub struct Address<A, Rc: RefCounter = Strong>(pub(crate) chan::Ptr<A, Rc>);
 
 impl<A, Rc: RefCounter> Debug for Address<A, Rc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Address").field(&self.0).finish()
+        let actor_type = std::any::type_name::<A>();
+        let rc_type = std::any::type_name::<Rc>()
+            .replace("xtra::chan::ptr::", "")
+            .replace("Tx", "");
+
+        f.debug_struct(&format!("Address<{}, {}>", actor_type, rc_type))
+            .field("addresses", &self.0.sender_count())
+            .field("mailboxes", &self.0.receiver_count())
+            .finish()
     }
 }
 

--- a/src/chan/ptr.rs
+++ b/src/chan/ptr.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::ops::Deref;
 use std::sync::{atomic, Arc};
 
@@ -64,6 +63,14 @@ where
     pub fn inner_ptr(&self) -> *const () {
         Arc::as_ptr(&self.inner) as *const ()
     }
+
+    pub fn sender_count(&self) -> usize {
+        self.inner.sender_count.load(atomic::Ordering::SeqCst)
+    }
+
+    pub fn receiver_count(&self) -> usize {
+        self.inner.receiver_count.load(atomic::Ordering::SeqCst)
+    }
 }
 
 impl<A, Rc> Ptr<A, Rc>
@@ -107,24 +114,6 @@ where
 
     fn deref(&self) -> &Self::Target {
         &self.inner
-    }
-}
-
-impl<A, Rc> fmt::Debug for Ptr<A, Rc>
-where
-    Rc: RefCounter,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use atomic::Ordering::SeqCst;
-
-        let act = std::any::type_name::<A>();
-        let rc = std::any::type_name::<Rc>()
-            .trim_start_matches(module_path!())
-            .trim_start_matches("::");
-        f.debug_struct(&format!("ChanPtr<{}, {}>", act, rc))
-            .field("rx_count", &self.inner.receiver_count.load(SeqCst))
-            .field("tx_count", &self.inner.sender_count.load(SeqCst))
-            .finish()
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -817,18 +817,14 @@ fn address_debug() {
 
     assert_eq!(
         format!("{:?}", addr1),
-        "Address(\
-            ChanPtr<basic::Greeter, TxStrong> { rx_count: 1, tx_count: 2 }\
-        )"
+        "Address<basic::Greeter, Strong> { addresses: 2, mailboxes: 1 }"
     );
 
     assert_eq!(format!("{:?}", addr1), format!("{:?}", addr2));
 
     assert_eq!(
         format!("{:?}", weak_addr),
-        "Address(\
-            ChanPtr<basic::Greeter, TxWeak> { rx_count: 1, tx_count: 2 }\
-        )"
+        "Address<basic::Greeter, Weak> { addresses: 2, mailboxes: 1 }"
     );
 }
 
@@ -841,16 +837,12 @@ fn message_channel_debug() {
 
     assert_eq!(
         format!("{:?}", mc),
-        "MessageChannel<basic::Hello, alloc::string::String>(\
-            ChanPtr<basic::Greeter, TxStrong> { rx_count: 1, tx_count: 1 }\
-        )"
+        "MessageChannel<basic::Greeter, basic::Hello, alloc::string::String, Strong> { addresses: 1, mailboxes: 1 }"
     );
 
     assert_eq!(
         format!("{:?}", weak_mc),
-        "MessageChannel<basic::Hello, alloc::string::String>(\
-            ChanPtr<basic::Greeter, TxWeak> { rx_count: 1, tx_count: 1 }\
-        )"
+        "MessageChannel<basic::Greeter, basic::Hello, alloc::string::String, Weak> { addresses: 1, mailboxes: 1 }"
     );
 }
 


### PR DESCRIPTION
This patch proposes a slightly more user-friendly debug output of addresses and message channels. Instead of rx/tx terminology, we use addresses and mailboxes.