### PR TITLE
Update lockfile before computing cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
 
+      - run: cargo +nightly update -Z minimal-versions
+
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.args }}
-
-      - run: cargo +nightly update -Z minimal-versions
 
       - run: cargo check-custom-fmt
 


### PR DESCRIPTION
`Swatinem/rust-cache` considers the lockfile it finds in the repo for its cache key. If we update it _after_ restoring the cache, the cache key will never match exactly.