### PR TITLE
chore: add explicit macros feature to manifest

### DIFF
--- a/xtra/Cargo.toml
+++ b/xtra/Cargo.toml
@@ -48,6 +48,7 @@ futures-util = "0.3.21"
 
 [features]
 default = []
+macros = ["dep:macros"]
 instrumentation = ["dep:tracing"]
 async_std = ["dep:async-std"]
 smol = ["dep:smol"]


### PR DESCRIPTION
This PR adds an explicit `macros` feature to the manifest.

Typically one will look at the manifest `[features]` section to quickly identify which features are available (especially if not documented in the top-level crate docs). Searching for implicit features via optional dependencies leaves something to be desired.