### PR TITLE
Fix CI warning

### DIFF
--- a/xtra/examples/crude_bench.rs
+++ b/xtra/examples/crude_bench.rs
@@ -12,6 +12,7 @@ struct Counter {
 }
 
 struct Increment;
+#[allow(dead_code)]
 struct IncrementWithData(usize);
 struct GetCount;
 


### PR DESCRIPTION
We had a warning from beta clippy on the main branch. This should fix that.

Alternatively we may want to use it and throw away the value with `black_box`, but I'm not sure if this is stable yet